### PR TITLE
Only enable owner read/write bits for ~/.sheepit.conf

### DIFF
--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -6,7 +6,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 import com.sheepit.client.Configuration;
 import com.sheepit.client.Configuration.ComputeType;
@@ -109,6 +114,17 @@ public class SettingsLoader {
 					e.printStackTrace();
 				}
 			}
+		}
+
+		// Set Owner read/write
+		Set<PosixFilePermission> perms = new HashSet<PosixFilePermission>();
+		perms.add(PosixFilePermission.OWNER_READ);
+		perms.add(PosixFilePermission.OWNER_WRITE);
+
+		try {
+			Files.setPosixFilePermissions(Paths.get(path), perms);
+		} catch (IOException e) {
+			e.printStackTrace();
 		}
 	}
 	


### PR DESCRIPTION
I noticed that the .sheepit.conf file had the public read bit set, so I modified the code to prevent it (since it contains a password).