### PR TITLE
Fix start button enabling/disabling

### DIFF
--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -214,6 +214,7 @@ public class Settings implements Activity {
 		n += sep;
 		
 		saveButton = new JButton("Start");
+		checkDisplaySaveButton();
 		saveButton.setBounds(start_label_right, n, 80, size_height_label);
 		saveButton.addActionListener(new SaveAction());
 		parent.getContentPane().add(saveButton);
@@ -393,11 +394,11 @@ public class Settings implements Activity {
 		
 		@Override
 		public void keyReleased(KeyEvent arg0) {
+			checkDisplaySaveButton();
 		}
 		
 		@Override
 		public void keyTyped(KeyEvent arg0) {
-			checkDisplaySaveButton();
 		}
 		
 	}


### PR DESCRIPTION
I noticed a few situations when the start button would be enabled or disabled at the wrong times. The changes I made should correct the following issues:

1. If you type your username and then paste password from the clipboard, the start button will remain disabled despite both the username and passwords being filled. This is because pasting does not trigger the `keyTyped` event. To fix this I simply moved the `checkDisplaySaveButton` call to the `keyReleased` event, which is called by pasting and regular typing.
2. When the client initially starts, the start button is enabled even if the username or password field is empty. To fix this I added a call to `checkDisplaySaveButton` before the button was added to the content pane.