### PR TITLE
Implemented flexible layout for swing

### DIFF
--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -19,10 +19,15 @@
 
 package com.sheepit.client.standalone;
 
+import java.awt.Color;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.net.URL;
 
+import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
@@ -78,7 +83,7 @@ public class GuiSwing extends JFrame implements Gui {
 		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		
 		panel = new JPanel();
-		panel.setLayout(null);
+		panel.setLayout(new GridBagLayout());
 		setContentPane(this.panel);
 		panel.setBorder(new EmptyBorder(5, 5, 5, 5));
 		
@@ -146,6 +151,19 @@ public class GuiSwing extends JFrame implements Gui {
 	@Override
 	public void setClient(Client cli) {
 		client = cli;
+	}
+	
+	public void addPadding(int x, int y, int width, int height) {
+		GridBagConstraints constraints = new GridBagConstraints();
+		JLabel label = new JLabel("");
+		constraints.fill = GridBagConstraints.BOTH;
+		constraints.weightx = 1.0;
+		constraints.weighty = 1.0;
+		constraints.gridwidth = width;
+		constraints.gridheight = height;
+		constraints.gridx = x;
+		constraints.gridy = y;
+		getContentPane().add(label, constraints);
 	}
 	
 	public Configuration getConfiguration() {

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -1,6 +1,7 @@
 package com.sheepit.client.standalone.swing.activity;
 
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
@@ -14,12 +15,15 @@ import java.util.LinkedList;
 import java.util.List;
 
 import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JSlider;
 import javax.swing.JTextField;
@@ -68,7 +72,7 @@ public class Settings implements Activity {
 		List<GPUDevice> gpus = GPU.listDevices();
 		
 		GridBagConstraints constraints = new GridBagConstraints();
-		int columns = Math.max(5, 4 + (gpus != null ? gpus.size() : 0));
+		int columns = 4 + (gpus != null ? gpus.size() : 0);
 		int currentRow = 0;
 		
 		parent.addPadding(1, ++currentRow, columns - 2, 1);
@@ -76,7 +80,6 @@ public class Settings implements Activity {
 		
 		ImageIcon image = new ImageIcon(getClass().getResource("/title.png"));
 		JLabel labelImage = new JLabel(image);
-		labelImage.setBorder(BorderFactory.createMatteBorder(0, 0, 2, 0, Color.DARK_GRAY));
 		constraints.fill = GridBagConstraints.BOTH;
 		constraints.weightx = 1.0;
 		constraints.weighty = 3.0;
@@ -153,20 +156,22 @@ public class Settings implements Activity {
 			destination = config.getStorageDir().getName();
 		}
 		
+		JPanel cacheDirWrapper = new JPanel();
+		cacheDirWrapper.setLayout(new BoxLayout(cacheDirWrapper, BoxLayout.LINE_AXIS));
 		cacheDirText = new JLabel(destination);
-		constraints.weightx = 1.0;
-		constraints.gridwidth = columns - 4;
-		constraints.gridx = 2;
-		parent.getContentPane().add(cacheDirText, constraints);
+		cacheDirWrapper.add(cacheDirText);
+		
+		cacheDirWrapper.add(Box.createHorizontalGlue());
 		
 		cacheDirChooser = new JFileChooser();
 		cacheDirChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 		JButton openButton = new JButton("...");
 		openButton.addActionListener(new ChooseFileAction());
-		constraints.weightx = 0.0;
-		constraints.gridwidth = 1;
-		constraints.gridx = columns - 2;
-		parent.getContentPane().add(openButton, constraints);
+		cacheDirWrapper.add(openButton);
+		
+		constraints.gridwidth = columns - 3;
+		constraints.gridx = 2;
+		parent.getContentPane().add(cacheDirWrapper, constraints);
 		
 		parent.addPadding(1, ++currentRow, columns - 2, 1);
 		++currentRow;

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -1,5 +1,9 @@
 package com.sheepit.client.standalone.swing.activity;
 
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -9,6 +13,7 @@ import java.net.MalformedURLException;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -60,64 +65,88 @@ public class Settings implements Activity {
 		Configuration config = parent.getConfiguration();
 		new SettingsLoader().merge(config);
 		
-		int size_height_label = 24;
-		int start_label_left = 109;
-		int start_label_right = 265;
-		int end_label_right = 490;
-		int n = 5;
-		int sep = 40;
+		List<GPUDevice> gpus = GPU.listDevices();
+		
+		GridBagConstraints constraints = new GridBagConstraints();
+		int columns = Math.max(5, 4 + (gpus != null ? gpus.size() : 0));
+		int currentRow = 0;
+		
+		parent.addPadding(1, ++currentRow, columns - 2, 1);
+		++currentRow;
 		
 		ImageIcon image = new ImageIcon(getClass().getResource("/title.png"));
 		JLabel labelImage = new JLabel(image);
-		labelImage.setBounds(600 / 2 - 265 / 2, n, 265, 130 + n);
-		n = labelImage.getHeight();
-		parent.getContentPane().add(labelImage);
+		labelImage.setBorder(BorderFactory.createMatteBorder(0, 0, 2, 0, Color.DARK_GRAY));
+		constraints.fill = GridBagConstraints.BOTH;
+		constraints.weightx = 1.0;
+		constraints.weighty = 3.0;
+		constraints.gridwidth = columns - 2;
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(labelImage, constraints);
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, columns - 2, 1);
+		++currentRow;
 		
 		JLabel loginLabel = new JLabel("Login:");
-		loginLabel.setBounds(start_label_left, n, 170, size_height_label);
-		parent.getContentPane().add(loginLabel);
+		constraints.fill = GridBagConstraints.HORIZONTAL;
+		constraints.weighty = 0.0;
+		constraints.gridwidth = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(loginLabel, constraints);
 		
 		login = new JTextField();
-		login.setBounds(start_label_right, n, end_label_right - start_label_right, size_height_label);
 		login.setText(parent.getConfiguration().login());
 		login.setColumns(20);
 		login.addKeyListener(new CheckCanStart());
-		parent.getContentPane().add(login);
+		constraints.gridwidth = columns - 3;
+		constraints.gridx = 2;
+		parent.getContentPane().add(login, constraints);
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, columns - 2, 1);
+		++currentRow;
 		
 		JLabel passwordLabel = new JLabel("Password:");
-		passwordLabel.setBounds(start_label_left, n, 170, size_height_label);
-		parent.getContentPane().add(passwordLabel);
+		constraints.weighty = 0.0;
+		constraints.gridwidth = 1;
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(passwordLabel, constraints);
 		
 		password = new JPasswordField();
-		password.setBounds(start_label_right, n, end_label_right - start_label_right, size_height_label);
 		password.setText(parent.getConfiguration().password());
 		password.setColumns(10);
 		password.addKeyListener(new CheckCanStart());
-		parent.getContentPane().add(password);
+		constraints.gridwidth = columns - 3;
+		constraints.gridx = 2;
+		parent.getContentPane().add(password, constraints);
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, columns - 2, 1);
+		++currentRow;
 		
 		JLabel proxyLabel = new JLabel("Proxy:");
-		proxyLabel.setBounds(start_label_left, n, 170, size_height_label);
 		proxyLabel.setToolTipText("http://login:password@host:port");
-		parent.getContentPane().add(proxyLabel);
+		constraints.gridwidth = 1;
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(proxyLabel, constraints);
 		
 		proxy = new JTextField();
-		proxy.setBounds(start_label_right, n, end_label_right - start_label_right, size_height_label);
 		proxy.setToolTipText("http://login:password@host:port");
 		proxy.setText(parent.getConfiguration().getProxy());
 		proxy.addKeyListener(new CheckCanStart());
-		parent.getContentPane().add(proxy);
+		constraints.gridwidth = columns - 3;
+		constraints.gridx = 2;
+		parent.getContentPane().add(proxy, constraints);
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, columns - 2, 1);
+		++currentRow;
 		
 		JLabel cacheLabel = new JLabel("Working directory:");
-		cacheLabel.setBounds(start_label_left, n, 240, size_height_label);
-		parent.getContentPane().add(cacheLabel);
+		constraints.gridwidth = 1;
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(cacheLabel, constraints);
 		
 		String destination = DUMMY_CACHE_DIR;
 		if (config.getUserSpecifiedACacheDir()) {
@@ -125,21 +154,27 @@ public class Settings implements Activity {
 		}
 		
 		cacheDirText = new JLabel(destination);
-		cacheDirText.setBounds(start_label_right, n, 240, size_height_label);
-		parent.getContentPane().add(cacheDirText);
+		constraints.weightx = 1.0;
+		constraints.gridwidth = columns - 4;
+		constraints.gridx = 2;
+		parent.getContentPane().add(cacheDirText, constraints);
 		
 		cacheDirChooser = new JFileChooser();
 		cacheDirChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 		JButton openButton = new JButton("...");
 		openButton.addActionListener(new ChooseFileAction());
-		openButton.setBounds(end_label_right - 50, n, 50, size_height_label);
-		parent.getContentPane().add(openButton);
+		constraints.weightx = 0.0;
+		constraints.gridwidth = 1;
+		constraints.gridx = columns - 2;
+		parent.getContentPane().add(openButton, constraints);
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, columns - 2, 1);
+		++currentRow;
 		
 		JLabel computeMethodLabel = new JLabel("Use:");
-		computeMethodLabel.setBounds(start_label_left, n, 240, size_height_label);
-		parent.getContentPane().add(computeMethodLabel);
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(computeMethodLabel, constraints);
 		
 		ComputeType method = config.getComputeMethod();
 		useCPU = new JCheckBox("CPU");
@@ -158,15 +193,15 @@ public class Settings implements Activity {
 			gpuChecked = true;
 		}
 		
-		int size = 60;
 		useCPU.addActionListener(new CpuChangeAction());
-		useCPU.setBounds(start_label_right, n, size, size_height_label);
-		parent.getContentPane().add(useCPU);
+		constraints.gridwidth = Math.max(1, columns - (gpus != null ? gpus.size() : 0) - 3);
+		constraints.gridx = 2;
+		parent.getContentPane().add(useCPU, constraints);
 		
-		List<GPUDevice> gpus = GPU.listDevices();
+		constraints.gridwidth = 1;
 		if (gpus != null) {
-			for (GPUDevice gpu : gpus) {
-				n += 20;
+			for (int i=0; i < gpus.size(); i++) {
+				GPUDevice gpu = gpus.get(i);
 				JCheckBoxGPU gpuCheckBox = new JCheckBoxGPU(gpu);
 				gpuCheckBox.setToolTipText(gpu.getCudaName());
 				if (gpuChecked) {
@@ -175,14 +210,15 @@ public class Settings implements Activity {
 						gpuCheckBox.setSelected(gpuChecked);
 					}
 				}
-				gpuCheckBox.setBounds(start_label_right, n, 200, size_height_label);
 				gpuCheckBox.addActionListener(new GpuChangeAction());
-				parent.getContentPane().add(gpuCheckBox);
+				constraints.gridx = i + 3;
+				parent.getContentPane().add(gpuCheckBox, constraints);
 				useGPUs.add(gpuCheckBox);
 			}
 		}
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, columns - 2, 1);
+		++currentRow;
 		
 		CPU cpu = new CPU();
 		if (cpu.cores() > 1) { // if only one core is available, no need to show the choice
@@ -193,31 +229,46 @@ public class Settings implements Activity {
 			cpuCores.setPaintLabels(true);
 			cpuCores.setValue(config.getNbCores() != -1 ? config.getNbCores() : cpuCores.getMaximum());
 			JLabel coreLabel = new JLabel("CPU cores:");
-			coreLabel.setBounds(start_label_left, n, 170, size_height_label);
-			parent.getContentPane().add(coreLabel);
-			cpuCores.setBounds(start_label_right, n, end_label_right - start_label_right, size_height_label * 2);
-			parent.getContentPane().add(cpuCores);
-			n += sep + size_height_label;
+			constraints.gridx = 1;
+			constraints.gridy = currentRow;
+			parent.getContentPane().add(coreLabel, constraints);
+			constraints.gridwidth = columns - 3;
+			constraints.gridx = 2;
+			parent.getContentPane().add(cpuCores, constraints);
+			
+			parent.addPadding(1, ++currentRow, columns - 2, 1);
+			++currentRow;
 		}
 		
 		saveFile = new JCheckBox("Save settings", true);
-		saveFile.setBounds(start_label_right, n, end_label_right - start_label_right, size_height_label);
-		parent.getContentPane().add(saveFile);
+		constraints.gridwidth = columns - 3;
+		constraints.gridx = 2;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(saveFile, constraints);
 		
-		n += 20;
+		parent.addPadding(1, ++currentRow, columns - 2, 1);
+		++currentRow;
 		
 		autoSignIn = new JCheckBox("Auto sign in", config.getAutoSignIn());
-		autoSignIn.setBounds(start_label_right, n, end_label_right - start_label_right, size_height_label);
 		autoSignIn.addActionListener(new AutoSignInChangeAction());
-		parent.getContentPane().add(autoSignIn);
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(autoSignIn, constraints);
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, columns - 2, 1);
+		++currentRow;
 		
 		saveButton = new JButton("Start");
 		checkDisplaySaveButton();
-		saveButton.setBounds(start_label_right, n, 80, size_height_label);
 		saveButton.addActionListener(new SaveAction());
-		parent.getContentPane().add(saveButton);
+		constraints.gridwidth = columns - 2;
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(saveButton, constraints);
+		
+		parent.addPadding(1, ++currentRow, columns - 2, 1);
+		parent.addPadding(0, 0, 1, currentRow + 1);
+		parent.addPadding(columns - 1, 0, 1, currentRow + 1);
+		
 		
 		if (haveAutoStarted == false && config.getAutoSignIn() && checkDisplaySaveButton()) {
 			// auto start

--- a/src/com/sheepit/client/standalone/swing/activity/Working.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Working.java
@@ -1,5 +1,7 @@
 package com.sheepit.client.standalone.swing.activity;
 
+import java.awt.Color;
+import java.awt.GridBagConstraints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
@@ -8,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import javax.imageio.ImageIO;
+import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -39,75 +42,99 @@ public class Working implements Activity {
 	
 	@Override
 	public void show() {
-		int n = 10;
-		int size_height_label = 24;
-		int sep = 45;
-		int start_label_left = 109;
-		int start_label_right = 280;
-		int end_label_right = 490;
+		GridBagConstraints constraints = new GridBagConstraints();
+		int currentRow = 0;
+		
+		parent.addPadding(1, ++currentRow, 2, 1);
+		++currentRow;
 		
 		ImageIcon image = new ImageIcon(getClass().getResource("/title.png"));
 		JLabel labelImage = new JLabel(image);
-		labelImage.setBounds(600 / 2 - 265 / 2, n, 265, 130 + n);
-		n = labelImage.getHeight();
-		parent.getContentPane().add(labelImage);
+		labelImage.setBorder(BorderFactory.createMatteBorder(0, 0, 2, 0, Color.DARK_GRAY));
+		constraints.fill = GridBagConstraints.BOTH;
+		constraints.weightx = 1.0;
+		constraints.weighty = 3.0;
+		constraints.gridwidth = 2;
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(labelImage, constraints);
 		
-		n += 40;
+		parent.addPadding(1, ++currentRow, 2, 1);
+		++currentRow;
 		
 		JLabel statusLabel = new JLabel("Status:");
-		statusLabel.setBounds(start_label_left, n, 240, size_height_label);
-		parent.getContentPane().add(statusLabel);
+		constraints.fill = GridBagConstraints.HORIZONTAL;
+		constraints.weighty = 0.0;
+		constraints.gridwidth = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(statusLabel, constraints);
 		
 		statusContent.setVerticalAlignment(JLabel.TOP);
 		statusContent.setVerticalTextPosition(JLabel.TOP);
-		statusContent.setBounds(start_label_right, n, 600 - 20 - start_label_right, size_height_label + sep - 3);
-		parent.getContentPane().add(statusContent);
+		constraints.gridx = 2;
+		parent.getContentPane().add(statusContent, constraints);
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, 2, 1);
+		++currentRow;
 		
 		JLabel creditsEarnedLabel = new JLabel("Credits earned:");
-		creditsEarnedLabel.setBounds(start_label_left, n, 240, size_height_label);
-		parent.getContentPane().add(creditsEarnedLabel);
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(creditsEarnedLabel, constraints);
 		
-		creditEarned.setBounds(start_label_right, n, end_label_right - start_label_right, size_height_label);
-		parent.getContentPane().add(creditEarned);
+		constraints.gridx = 2;
+		parent.getContentPane().add(creditEarned, constraints);
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, 2, 1);
+		++currentRow;
 		
 		JLabel renderedFrameLabel = new JLabel("Rendered frames:");
-		renderedFrameLabel.setBounds(start_label_left, n, 240, size_height_label);
-		parent.getContentPane().add(renderedFrameLabel);
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(renderedFrameLabel, constraints);
 		
-		renderedFrameContent.setBounds(start_label_right, n, end_label_right - start_label_right, size_height_label);
-		parent.getContentPane().add(renderedFrameContent);
+		constraints.gridx = 2;
+		parent.getContentPane().add(renderedFrameContent, constraints);
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, 2, 1);
+		++currentRow;
 		
 		JLabel remainingFrameLabel = new JLabel("Remaining frames:");
-		remainingFrameLabel.setBounds(start_label_left, n, 240, size_height_label);
-		parent.getContentPane().add(remainingFrameLabel);
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(remainingFrameLabel, constraints);
 		
-		remainingFrameContent.setBounds(start_label_right, n, end_label_right - start_label_right, size_height_label);
-		parent.getContentPane().add(remainingFrameContent);
+		constraints.gridx = 2;
+		parent.getContentPane().add(remainingFrameContent, constraints);
 		
-		n += sep;
+		parent.addPadding(1, ++currentRow, 2, 1);
+		++currentRow;
 		
 		JLabel lastRenderedFrameLabel = new JLabel("Last rendered frame:");
-		lastRenderedFrameLabel.setBounds(start_label_left, n, 240, size_height_label);
-		parent.getContentPane().add(lastRenderedFrameLabel);
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(lastRenderedFrameLabel, constraints);
 		
-		lastRender.setBounds(start_label_right, n, 200, 112);
-		parent.getContentPane().add(lastRender);
+		constraints.gridx = 2;
+		parent.getContentPane().add(lastRender, constraints);
+		
+		parent.addPadding(1, ++currentRow, 2, 1);
+		++currentRow;
 		
 		JButton settingsButton = new JButton("Settings");
-		settingsButton.setBounds(220, 500, 100, 25);
 		settingsButton.addActionListener(new SettingsAction());
-		parent.getContentPane().add(settingsButton);
+		constraints.gridx = 1;
+		constraints.gridy = currentRow;
+		parent.getContentPane().add(settingsButton, constraints);
 		
 		pauseButton = new JButton("Pause");
-		pauseButton.setBounds(330, 500, 100, 25);
 		pauseButton.addActionListener(new PauseAction());
-		parent.getContentPane().add(pauseButton);
+		constraints.gridx = 2;
+		parent.getContentPane().add(pauseButton, constraints);
+		
+		parent.addPadding(1, ++currentRow, 2, 1);
+		parent.addPadding(0, 0, 1, currentRow + 1);
+		parent.addPadding(3, 0, 1, currentRow + 1);
 	}
 	
 	public void setStatus(String msg_) {

--- a/src/com/sheepit/client/standalone/swing/activity/Working.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Working.java
@@ -50,7 +50,6 @@ public class Working implements Activity {
 		
 		ImageIcon image = new ImageIcon(getClass().getResource("/title.png"));
 		JLabel labelImage = new JLabel(image);
-		labelImage.setBorder(BorderFactory.createMatteBorder(0, 0, 2, 0, Color.DARK_GRAY));
 		constraints.fill = GridBagConstraints.BOTH;
 		constraints.weightx = 1.0;
 		constraints.weighty = 3.0;


### PR DESCRIPTION
The lack of progress on a flexible layout has been holding up pull requests #23 and #29, as well as just generally annoying me whenever I use the client, so I decided to do it myself.

The layout looks more or less the same as it did before, but it now adjusts based on the content and the size of the window. I have not been able to test how either GPU options or last rendered frame display affect the layout, however they *should* properly follow the layout.

Probably Closes #25