### PR TITLE
Core Affinity and small code formatting on Settings.java

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -57,5 +57,11 @@
         <delete dir="build"/>
         <delete dir="bin"/>
     </target>
+	
+    <target name="run">
+    	<antcall target="client" />
+        <java jar="bin/sheepit-client.jar" fork="true"/>
+    </target>
+	
  </project>
 

--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -363,12 +363,12 @@ public class Client {
 		this.log.debug("Client::askForStop");
 		this.running = false;
 	}
-        
+		
 	public void cancelStop() {
 		this.log.debug("Client::cancelStop");
 		this.running = true;
 	}
-        
+		
 	public boolean isRunning() {
 		return this.running;
 	}

--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -363,12 +363,12 @@ public class Client {
 		this.log.debug("Client::askForStop");
 		this.running = false;
 	}
-		
+        
 	public void cancelStop() {
 		this.log.debug("Client::cancelStop");
 		this.running = true;
 	}
-		
+        
 	public boolean isRunning() {
 		return this.running;
 	}

--- a/src/com/sheepit/client/Configuration.java
+++ b/src/com/sheepit/client/Configuration.java
@@ -47,6 +47,7 @@ public class Configuration {
 	private String proxy;
 	private int maxUploadingJob;
 	private int nbCores;
+	private long coreAffinity;
 	private ComputeType computeMethod;
 	private GPUDevice GPUDevice;
 	private boolean printLog;
@@ -73,6 +74,7 @@ public class Configuration {
 		this.extras = "";
 		this.autoSignIn = false;
 		this.UIType = null;
+		this.coreAffinity = 0;
 	}
 	
 	public String toString() {
@@ -121,6 +123,14 @@ public class Configuration {
 	
 	public int getNbCores() {
 		return this.nbCores;
+	}
+	
+	public long getCoreAffinity() {
+		return coreAffinity;
+	}
+
+	public void setCoreAffinity(long coreAffinity) {
+		this.coreAffinity = coreAffinity;
 	}
 	
 	public void setPrintLog(boolean val) {

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -210,7 +210,7 @@ public class Job {
 		
 		new_env.put("BLENDER_USER_CONFIG", config.workingDirectory.getAbsolutePath().replace("\\", "\\\\"));
 		new_env.put("PROCESS_CORE_AFFINITY", String.valueOf(config.getCoreAffinity()));
-
+		
 		for (String arg : command1) {
 			switch (arg) {
 				case ".c":

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -209,7 +209,8 @@ public class Job {
 		Map<String, String> new_env = new HashMap<String, String>();
 		
 		new_env.put("BLENDER_USER_CONFIG", config.workingDirectory.getAbsolutePath().replace("\\", "\\\\"));
-		
+		new_env.put("PROCESS_CORE_AFFINITY", String.valueOf(config.getCoreAffinity()));
+
 		for (String arg : command1) {
 			switch (arg) {
 				case ".c":

--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -40,7 +40,7 @@ public class SettingsLoader {
 		path = path_;
 	}
 	
-	public SettingsLoader(String login_, String password_, String proxy_, ComputeType computeMethod_, GPUDevice gpu_, int cores_,long affinity_, String cacheDir_, boolean autoSignIn_, String ui_) {
+	public SettingsLoader(String login_, String password_, String proxy_, ComputeType computeMethod_, GPUDevice gpu_, int cores_, long affinity_, String cacheDir_, boolean autoSignIn_, String ui_) {
 		path = getDefaultFilePath();
 		login = login_;
 		password = password_;
@@ -190,6 +190,7 @@ public class SettingsLoader {
 			if (prop.containsKey("cpu-affinity")) {
 				this.affinity = prop.getProperty("cpu-affinity");
 			}
+			
 			if (prop.containsKey("login")) {
 				this.login = prop.getProperty("login");
 			}

--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -186,6 +186,7 @@ public class SettingsLoader {
 			if (prop.containsKey("cpu-cores")) {
 				this.cores = prop.getProperty("cpu-cores");
 			}
+			
 			if (prop.containsKey("cpu-affinity")) {
 				this.affinity = prop.getProperty("cpu-affinity");
 			}
@@ -265,9 +266,9 @@ public class SettingsLoader {
 			config.setUseNbCores(Integer.valueOf(cores));
 		}
 		
-			if (config.getCoreAffinity() == 0 && affinity != null) {
-			config.setCoreAffinity(Long.valueOf(cores));
-			}
+		if (config.getCoreAffinity() == 0 && affinity != null) {
+			config.setCoreAffinity(Long.valueOf(affinity));
+		}
 		
 		if (config.getUserSpecifiedACacheDir() == false && cacheDir != null && new File(cacheDir).exists()) {
 			config.setCacheDir(new File(cacheDir));

--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -27,6 +27,7 @@ public class SettingsLoader {
 	private String computeMethod;
 	private String gpu;
 	private String cores;
+	private String affinity;
 	private String cacheDir;
 	private String autoSignIn;
 	private String ui;
@@ -39,7 +40,7 @@ public class SettingsLoader {
 		path = path_;
 	}
 	
-	public SettingsLoader(String login_, String password_, String proxy_, ComputeType computeMethod_, GPUDevice gpu_, int cores_, String cacheDir_, boolean autoSignIn_, String ui_) {
+	public SettingsLoader(String login_, String password_, String proxy_, ComputeType computeMethod_, GPUDevice gpu_, int cores_,long affinity_, String cacheDir_, boolean autoSignIn_, String ui_) {
 		path = getDefaultFilePath();
 		login = login_;
 		password = password_;
@@ -50,7 +51,7 @@ public class SettingsLoader {
 		if (cores_ > 0) {
 			cores = String.valueOf(cores_);
 		}
-		
+		affinity = String.valueOf(affinity_);
 		if (computeMethod_ != null) {
 			try {
 				computeMethod = computeMethod_.name();
@@ -92,6 +93,10 @@ public class SettingsLoader {
 			
 			if (cores != null) {
 				prop.setProperty("cpu-cores", cores);
+			}
+			
+			if (affinity != null) {
+				prop.setProperty("cpu-affinity", affinity);
 			}
 			
 			if (login != null) {
@@ -181,7 +186,9 @@ public class SettingsLoader {
 			if (prop.containsKey("cpu-cores")) {
 				this.cores = prop.getProperty("cpu-cores");
 			}
-			
+			if (prop.containsKey("cpu-affinity")) {
+				this.affinity = prop.getProperty("cpu-affinity");
+			}
 			if (prop.containsKey("login")) {
 				this.login = prop.getProperty("login");
 			}
@@ -257,6 +264,11 @@ public class SettingsLoader {
 		if (config.getNbCores() == -1  && cores != null) {
 			config.setUseNbCores(Integer.valueOf(cores));
 		}
+		
+			if (config.getCoreAffinity() == 0 && affinity != null) {
+			config.setCoreAffinity(Long.valueOf(cores));
+			}
+		
 		if (config.getUserSpecifiedACacheDir() == false && cacheDir != null && new File(cacheDir).exists()) {
 			config.setCacheDir(new File(cacheDir));
 		}

--- a/src/com/sheepit/client/Utils.java
+++ b/src/com/sheepit/client/Utils.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.BitSet;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -225,5 +226,25 @@ public class Utils {
 			output += seconds + "s";
 		}
 		return output;
+	}
+	
+	public static long convertBitset64ToLong(BitSet bs) {
+		long result = 0L;
+		for (int i = bs.nextSetBit(0); i >= 0 && i < 64; i = bs.nextSetBit(i + 1))
+			result |= 1L << i;
+		return result;
+	}
+
+	public static BitSet convertLongToBitset64(long value) {
+		BitSet bits = new BitSet();
+		int index = 0;
+		while (value != 0L) {
+			if (value % 2L != 0) {
+				bits.set(index);
+			}
+			++index;
+			value = value >>> 1;
+		}
+		return bits;
 	}
 }

--- a/src/com/sheepit/client/Utils.java
+++ b/src/com/sheepit/client/Utils.java
@@ -234,7 +234,7 @@ public class Utils {
 			result |= 1L << i;
 		return result;
 	}
-
+	
 	public static BitSet convertLongToBitset64(long value) {
 		BitSet bits = new BitSet();
 		int index = 0;

--- a/src/com/sheepit/client/os/Linux.java
+++ b/src/com/sheepit/client/os/Linux.java
@@ -162,10 +162,10 @@ public class Linux extends OS {
 		}
 		Process retProc = builder.start();
 		if (env.containsKey("PROCESS_CORE_AFFINITY") == false)
-            return retProc;
-        long coreaffinity = Long.valueOf(env.get("PROCESS_CORE_AFFINITY"));
-        int pidOfProc = LinuxProcess.getPid(retProc);
-        LinuxProcess.setAffinity(pidOfProc, coreaffinity);     
+			return retProc;
+		long coreaffinity = Long.valueOf(env.get("PROCESS_CORE_AFFINITY"));
+		int pidOfProc = LinuxProcess.getPid(retProc);
+		LinuxProcess.setAffinity(pidOfProc, coreaffinity);
 		return retProc;
 	}
 	

--- a/src/com/sheepit/client/os/Linux.java
+++ b/src/com/sheepit/client/os/Linux.java
@@ -27,6 +27,7 @@ import java.util.Scanner;
 
 import com.sheepit.client.Log;
 import com.sheepit.client.hardware.cpu.CPU;
+import com.sheepit.client.os.linux.LinuxProcess;
 
 public class Linux extends OS {
 	private final String NICE_BINARY_PATH = "nice";
@@ -159,7 +160,13 @@ public class Linux extends OS {
 		if (env_overight != null) {
 			env.putAll(env_overight);
 		}
-		return builder.start();
+		Process retProc = builder.start();
+		if (env.containsKey("PROCESS_CORE_AFFINITY") == false)
+            return retProc;
+        long coreaffinity = Long.valueOf(env.get("PROCESS_CORE_AFFINITY"));
+        int pidOfProc = LinuxProcess.getPid(retProc);
+        LinuxProcess.setAffinity(pidOfProc, coreaffinity);     
+		return retProc;
 	}
 	
 	protected void checkNiceAvailability() {

--- a/src/com/sheepit/client/os/Windows.java
+++ b/src/com/sheepit/client/os/Windows.java
@@ -133,6 +133,7 @@ public class Windows extends OS {
 		Process p = builder.start();
 		WinProcess wproc = new WinProcess(p);
 		wproc.setPriority(WinProcess.PRIORITY_BELOW_NORMAL);
+		wproc.SetProcessAffinity(env);
 		return p;
 	}
 	

--- a/src/com/sheepit/client/os/linux/LinuxProcess.java
+++ b/src/com/sheepit/client/os/linux/LinuxProcess.java
@@ -1,52 +1,49 @@
 package com.sheepit.client.os.linux;
 
 import java.lang.reflect.Field;
-import java.util.BitSet;
 
-import com.sheepit.client.Utils;
 import com.sun.jna.Library;
-import com.sun.jna.Memory;
 import com.sun.jna.Native;
-import com.sun.jna.PointerType;
-import com.sun.jna.ptr.PointerByReference;
 
 public class LinuxProcess {
-    
-    public static boolean setAffinity(int pid, long affinity) {
-        //System.out.println("setAffinity for pid:"+pid+" affinity"+affinity);
-        if (pid == -1)
-            return false;
-        if (affinity == 0) {
-            return false;
-        }
-        try {
-            long affinityMask[] = new long[16];
-            affinityMask[0] = affinity;
-            final int result = CLibrary.INSTANCE.sched_setaffinity(0, 16 * (Long.SIZE / 8), affinityMask);
-            return (result == 0);
-        } catch (Exception e) {
-            System.err.println("setAffinity error for pid:" + pid + " affinity" + affinity + " " + e);
-            return false;
-        }
-    }
-    
-    public static int getPid(Process process) {
-        try {
-            Class<?> ProcessImpl = process.getClass();
-            Field field = ProcessImpl.getDeclaredField("pid");
-            field.setAccessible(true);
-            return field.getInt(process);
-        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
-            return -1;
-        }
-    }   
-    
-    interface CLibrary extends Library {
-        CLibrary INSTANCE = (CLibrary)
-                Native.loadLibrary("c", CLibrary.class);
-
-        int sched_setaffinity(final int pid,
-                              final int cpusetsize,
-                              final long[] cpuset);
-    }
+	
+	public static boolean setAffinity(int pid, long affinity) {
+		if (pid == -1)
+			return false;
+		if (affinity == 0) {
+			return false;
+		}
+		try {
+			long affinityMask[] = new long[16];
+			affinityMask[0] = affinity;
+			final int result = CLibrary.INSTANCE.sched_setaffinity(0, 16 * (Long.SIZE / 8), affinityMask);
+			return (result == 0);
+		}
+		catch (Exception e) {
+			System.err.println("setAffinity error for pid:" + pid + " affinity" + affinity + " " + e);
+			return false;
+		}
+	}
+	
+	public static int getPid(Process process) {
+		try {
+			Class<?> ProcessImpl = process.getClass();
+			Field field = ProcessImpl.getDeclaredField("pid");
+			field.setAccessible(true);
+			return field.getInt(process);
+		}
+		catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
+			return -1;
+		}
+	}
+	
+	interface CLibrary extends Library {
+		CLibrary INSTANCE = (CLibrary) Native.loadLibrary("c", CLibrary.class);
+		
+		/*
+		 * sched_setaffinity, sched_getaffinity - set and get a process's CPU affinity mask 
+		 * see http://linux.die.net/man/2/sched_setaffinity
+		 */
+		int sched_setaffinity(final int pid, final int cpusetsize, final long[] cpuset);
+	}
 }

--- a/src/com/sheepit/client/os/linux/LinuxProcess.java
+++ b/src/com/sheepit/client/os/linux/LinuxProcess.java
@@ -1,0 +1,53 @@
+package com.sheepit.client.os.linux;
+
+import java.lang.reflect.Field;
+import java.util.BitSet;
+
+import com.sheepit.client.Utils;
+import com.sun.jna.Library;
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.PointerType;
+import com.sun.jna.ptr.PointerByReference;
+
+public class LinuxProcess {
+    
+    public static boolean setAffinity(int pid, long affinity) {
+        BitSet bs = Utils.convertLongToBitset64(affinity);
+        System.out.println("setAffinity for pid:"+pid+" affinity"+affinity);
+        if (pid == -1)
+            return false;
+        if (bs.isEmpty())
+            return false;
+        try {
+            byte[] buff = bs.toByteArray();
+            int cpuSetSizeInBytes = buff.length;
+            Memory cpusetArray = new Memory(cpuSetSizeInBytes);
+            cpusetArray.write(0, buff, 0, buff.length);
+            return CLibrary.INSTANCE.sched_setaffinity(pid, cpuSetSizeInBytes, new PointerByReference(cpusetArray)) == 0;
+        } catch (Exception e) {
+            System.err.println("setAffinity error for pid:"+pid+" affinity"+affinity + " " + e);
+            return false;
+        }
+    }
+    
+    public static int getPid(Process process) {
+        try {
+            Class<?> ProcessImpl = process.getClass();
+            Field field = ProcessImpl.getDeclaredField("pid");
+            field.setAccessible(true);
+            return field.getInt(process);
+        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
+            return -1;
+        }
+    }   
+    
+    interface CLibrary extends Library {
+        CLibrary INSTANCE = (CLibrary)
+                Native.loadLibrary("c", CLibrary.class);
+
+        int sched_setaffinity(final int pid,
+                              final int cpusetsize,
+                              final PointerType cpuset);
+    }
+}

--- a/src/com/sheepit/client/os/linux/LinuxProcess.java
+++ b/src/com/sheepit/client/os/linux/LinuxProcess.java
@@ -13,20 +13,19 @@ import com.sun.jna.ptr.PointerByReference;
 public class LinuxProcess {
     
     public static boolean setAffinity(int pid, long affinity) {
-        BitSet bs = Utils.convertLongToBitset64(affinity);
-        System.out.println("setAffinity for pid:"+pid+" affinity"+affinity);
+        //System.out.println("setAffinity for pid:"+pid+" affinity"+affinity);
         if (pid == -1)
             return false;
-        if (bs.isEmpty())
+        if (affinity == 0) {
             return false;
+        }
         try {
-            byte[] buff = bs.toByteArray();
-            int cpuSetSizeInBytes = buff.length;
-            Memory cpusetArray = new Memory(cpuSetSizeInBytes);
-            cpusetArray.write(0, buff, 0, buff.length);
-            return CLibrary.INSTANCE.sched_setaffinity(pid, cpuSetSizeInBytes, new PointerByReference(cpusetArray)) == 0;
+            long affinityMask[] = new long[16];
+            affinityMask[0] = affinity;
+            final int result = CLibrary.INSTANCE.sched_setaffinity(0, 16 * (Long.SIZE / 8), affinityMask);
+            return (result == 0);
         } catch (Exception e) {
-            System.err.println("setAffinity error for pid:"+pid+" affinity"+affinity + " " + e);
+            System.err.println("setAffinity error for pid:" + pid + " affinity" + affinity + " " + e);
             return false;
         }
     }
@@ -48,6 +47,6 @@ public class LinuxProcess {
 
         int sched_setaffinity(final int pid,
                               final int cpusetsize,
-                              final PointerType cpuset);
+                              final long[] cpuset);
     }
 }

--- a/src/com/sheepit/client/os/windows/Kernel32Lib.java
+++ b/src/com/sheepit/client/os/windows/Kernel32Lib.java
@@ -212,8 +212,6 @@ public interface Kernel32Lib extends Library {
 	 */
 	public int SetErrorMode(DWORD uMode);
 	
-	
-	
 	/**
 	 * See : https://msdn.microsoft.com/en-us/library/windows/desktop/ms686247%28v=vs.85%29.aspx
 	 * 
@@ -222,5 +220,5 @@ public interface Kernel32Lib extends Library {
 	 * @return If the function succeeds, the return value is the thread's previous affinity mask.
 	 */
 	public boolean SetProcessAffinityMask(HANDLE hProcess, DWORD_PTR dwProcessAffinityMask);
-	
+
 }

--- a/src/com/sheepit/client/os/windows/Kernel32Lib.java
+++ b/src/com/sheepit/client/os/windows/Kernel32Lib.java
@@ -21,6 +21,7 @@ import com.sun.jna.Library;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.BaseTSD;
+import com.sun.jna.platform.win32.BaseTSD.DWORD_PTR;
 import com.sun.jna.platform.win32.WinDef;
 import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinNT;
@@ -210,5 +211,16 @@ public interface Kernel32Lib extends Library {
 	 * @param uMode The process error mode. This parameter can be one or more of the following values.
 	 */
 	public int SetErrorMode(DWORD uMode);
+	
+	
+	
+	/**
+	 * See : https://msdn.microsoft.com/en-us/library/windows/desktop/ms686247%28v=vs.85%29.aspx
+	 * 
+	 * @param hThread
+	 * @param dwThreadAffinityMask
+	 * @return If the function succeeds, the return value is the thread's previous affinity mask.
+	 */
+	public boolean SetProcessAffinityMask(HANDLE hProcess, DWORD_PTR dwProcessAffinityMask);
 	
 }

--- a/src/com/sheepit/client/os/windows/WinProcess.java
+++ b/src/com/sheepit/client/os/windows/WinProcess.java
@@ -84,11 +84,11 @@ public class WinProcess {
 	public WinProcess(int pid_) throws IOException {
 		this();
 		this.handle = Kernel32.INSTANCE.OpenProcess(0x0400 | // PROCESS_QUERY_INFORMATION
-													0x0800 | // PROCESS_SUSPEND_RESUME
-													0x0001 | // PROCESS_TERMINATE
-													0x0200 | // PROCESS_SET_INFORMATION
-													0x00100000, // SYNCHRONIZE
-													false, pid_);
+				0x0800 | // PROCESS_SUSPEND_RESUME
+				0x0001 | // PROCESS_TERMINATE
+				0x0200 | // PROCESS_SET_INFORMATION
+				0x00100000, // SYNCHRONIZE
+				false, pid_);
 		if (this.handle == null) {
 			throw new IOException("OpenProcess failed: " + Kernel32Util.formatMessageFromLastErrorCode(Kernel32.INSTANCE.GetLastError()) + " (pid: " + pid_ + ")");
 		}
@@ -133,7 +133,8 @@ public class WinProcess {
 			if (coreaffinity == 0)
 				return false;
 			return this.kernel32lib.SetProcessAffinityMask(this.handle, new DWORD_PTR(coreaffinity));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			return false;
 		}
 	}

--- a/src/com/sheepit/client/os/windows/WinProcess.java
+++ b/src/com/sheepit/client/os/windows/WinProcess.java
@@ -124,18 +124,14 @@ public class WinProcess {
 	}
 	
 	public boolean SetProcessAffinity(Map<String, String> env) {
-		System.out.println("get env");
 		if (env == null)
 			return false;
 		try {
-			System.out.println("get PROCESS_CORE_AFFINITY env");
 			if (env.containsKey("PROCESS_CORE_AFFINITY") == false)
 				return false;
-			System.out.println("get long env");
 			long coreaffinity = Long.valueOf(env.get("PROCESS_CORE_AFFINITY"));
 			if (coreaffinity == 0)
 				return false;
-			System.out.println("coreaffinity="+coreaffinity);
 			return this.kernel32lib.SetProcessAffinityMask(this.handle, new DWORD_PTR(coreaffinity));
 		} catch (Exception e) {
 			return false;

--- a/src/com/sheepit/client/os/windows/WinProcess.java
+++ b/src/com/sheepit/client/os/windows/WinProcess.java
@@ -23,9 +23,11 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.BaseTSD.DWORD_PTR;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.Kernel32Util;
 import com.sun.jna.platform.win32.WinDef.DWORD;
@@ -119,6 +121,25 @@ public class WinProcess {
 	
 	public boolean setPriority(int priority) {
 		return this.kernel32lib.SetPriorityClass(this.handle, priority);
+	}
+	
+	public boolean SetProcessAffinity(Map<String, String> env) {
+		System.out.println("get env");
+		if (env == null)
+			return false;
+		try {
+			System.out.println("get PROCESS_CORE_AFFINITY env");
+			if (env.containsKey("PROCESS_CORE_AFFINITY") == false)
+				return false;
+			System.out.println("get long env");
+			long coreaffinity = Long.valueOf(env.get("PROCESS_CORE_AFFINITY"));
+			if (coreaffinity == 0)
+				return false;
+			System.out.println("coreaffinity="+coreaffinity);
+			return this.kernel32lib.SetProcessAffinityMask(this.handle, new DWORD_PTR(coreaffinity));
+		} catch (Exception e) {
+			return false;
+		}
 	}
 	
 	private void terminate() {

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -1,20 +1,16 @@
 package com.sheepit.client.standalone.swing.activity;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
 import java.awt.GridBagConstraints;
-import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.io.File;
 import java.net.MalformedURLException;
+import java.util.BitSet;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
@@ -26,10 +22,15 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JSlider;
+import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableModel;
+
 import com.sheepit.client.Configuration;
 import com.sheepit.client.Configuration.ComputeType;
 import com.sheepit.client.SettingsLoader;
+import com.sheepit.client.Utils;
 import com.sheepit.client.hardware.cpu.CPU;
 import com.sheepit.client.hardware.gpu.GPU;
 import com.sheepit.client.hardware.gpu.GPUDevice;
@@ -49,8 +50,8 @@ public class Settings implements Activity {
 	private JCheckBox useCPU;
 	private List<JCheckBoxGPU> useGPUs;
 	private JSlider cpuCores;
+	private JTable affinitytable = null;
 	private JTextField proxy;
-	
 	private JCheckBox saveFile;
 	private JCheckBox autoSignIn;
 	JButton saveButton;
@@ -243,6 +244,42 @@ public class Settings implements Activity {
 			
 			parent.addPadding(1, ++currentRow, columns - 2, 1);
 			++currentRow;
+			
+			JLabel afinityLabel = new JLabel("CPU Afinity:");
+			constraints.gridx = 1;
+			constraints.gridy = currentRow;
+			parent.getContentPane().add(afinityLabel, constraints);
+			
+			final int max_colums = 64;
+			int nbcores = cpu.cores();
+			int nb_colums = nbcores < max_colums ? nbcores : max_colums;
+			Object[] columnNames = new String[nb_colums];
+			Object[][] data = new Object[1][ nb_colums ];
+			BitSet bs = Utils.convertLongToBitset64(config.getCoreAffinity());
+			for(int i=0 ; i<nb_colums ; i++ ){
+				columnNames[i] = "CPU" + i;
+				data[0][i] = bs.isEmpty() ? true : bs.get(i);
+			}
+			DefaultTableModel model = new DefaultTableModel(data, columnNames);
+			affinitytable = new JTable(model) {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Class getColumnClass(int column) {
+					return Boolean.class;
+				}
+			};
+			GridBagConstraints affinityContraints = new GridBagConstraints();			
+			affinityContraints.fill = GridBagConstraints.BOTH;
+			affinityContraints.weightx = 0.0;
+			affinityContraints.weighty = 0.0;
+			affinityContraints.gridx = 2;
+			affinityContraints.gridy = currentRow;
+			affinityContraints.gridwidth = columns - 3;
+			affinityContraints.gridheight = 1;
+			affinitytable.setRowSelectionAllowed(false);
+			parent.getContentPane().add(affinitytable, affinityContraints);
+			parent.addPadding(1, ++currentRow, columns - 2, 1);
+			++currentRow;
 		}
 		
 		saveFile = new JCheckBox("Save settings", true);
@@ -396,6 +433,18 @@ public class Settings implements Activity {
 				config.setUseNbCores(cpu_cores);
 			}
 			
+			long coreAffinity = 0;
+			if (affinitytable != null) {
+				TableModel model = affinitytable.getModel();
+				BitSet bs = new BitSet(64);
+				for (int i=0;i<model.getColumnCount();i++) {
+					if ((Boolean)model.getValueAt(0, i) && i<64)
+						bs.set(i);
+				}
+				coreAffinity = Utils.convertBitset64ToLong(bs);
+			}
+			config.setCoreAffinity(coreAffinity);
+			
 			String proxyText = null;
 			if (proxy != null) {
 				try {
@@ -417,7 +466,7 @@ public class Settings implements Activity {
 			}
 			
 			if (saveFile.isSelected()) {
-				new SettingsLoader(login.getText(), new String(password.getPassword()), proxyText, method, selected_gpu, cpu_cores, cachePath, autoSignIn.isSelected(), GuiSwing.type).saveFile();
+				new SettingsLoader(login.getText(), new String(password.getPassword()), proxyText, method, selected_gpu, cpu_cores, coreAffinity, cachePath, autoSignIn.isSelected(), GuiSwing.type).saveFile();
 			}
 			else {
 				try {

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -24,6 +24,11 @@ import javax.swing.JPasswordField;
 import javax.swing.JSlider;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.TableModelEvent;
+import javax.swing.event.TableModelListener;
+import javax.swing.plaf.SliderUI;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableModel;
 
@@ -234,6 +239,13 @@ public class Settings implements Activity {
 			cpuCores.setPaintTicks(true);
 			cpuCores.setPaintLabels(true);
 			cpuCores.setValue(config.getNbCores() != -1 ? config.getNbCores() : cpuCores.getMaximum());
+			cpuCores.getModel().addChangeListener(new ChangeListener() {
+				@Override
+				public void stateChanged(ChangeEvent e) {
+					 if (cpuCores.getValueIsAdjusting() == true) 
+						 return;
+				}
+			});
 			JLabel coreLabel = new JLabel("CPU cores:");
 			constraints.gridx = 1;
 			constraints.gridy = currentRow;
@@ -268,6 +280,20 @@ public class Settings implements Activity {
 					return Boolean.class;
 				}
 			};
+			affinitytable.getModel().addTableModelListener(new TableModelListener() {
+				@Override
+				public void tableChanged(TableModelEvent e) {
+					if (e.getType() != TableModelEvent.UPDATE)
+						return;
+					TableModel tm = affinitytable.getModel();
+					int count = 0;
+					for (int i = 0; i < tm.getColumnCount(); i++)
+						if ((boolean) tm.getValueAt(0, i))
+							count++;
+					if (count > 0 && count != cpuCores.getValue())
+						cpuCores.setValue(count);
+				}
+			});
 			GridBagConstraints affinityContraints = new GridBagConstraints();			
 			affinityContraints.fill = GridBagConstraints.BOTH;
 			affinityContraints.weightx = 0.0;

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -28,7 +28,6 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
-import javax.swing.plaf.SliderUI;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableModel;
 
@@ -211,7 +210,7 @@ public class Settings implements Activity {
 		
 		constraints.gridwidth = 1;
 		if (gpus != null) {
-			for (int i=0; i < gpus.size(); i++) {
+			for (int i = 0; i < gpus.size(); i++) {
 				GPUDevice gpu = gpus.get(i);
 				JCheckBoxGPU gpuCheckBox = new JCheckBoxGPU(gpu);
 				gpuCheckBox.setToolTipText(gpu.getCudaName());
@@ -242,8 +241,8 @@ public class Settings implements Activity {
 			cpuCores.getModel().addChangeListener(new ChangeListener() {
 				@Override
 				public void stateChanged(ChangeEvent e) {
-					 if (cpuCores.getValueIsAdjusting() == true) 
-						 return;
+					if (cpuCores.getValueIsAdjusting() == true)
+						return;
 				}
 			});
 			JLabel coreLabel = new JLabel("CPU cores:");
@@ -266,17 +265,18 @@ public class Settings implements Activity {
 			int nbcores = cpu.cores();
 			int nb_colums = nbcores < max_colums ? nbcores : max_colums;
 			Object[] columnNames = new String[nb_colums];
-			Object[][] data = new Object[1][ nb_colums ];
+			Object[][] data = new Object[1][nb_colums];
 			BitSet bs = Utils.convertLongToBitset64(config.getCoreAffinity());
-			for(int i=0 ; i<nb_colums ; i++ ){
+			for (int i = 0; i < nb_colums; i++) {
 				columnNames[i] = "CPU" + i;
 				data[0][i] = bs.isEmpty() ? true : bs.get(i);
 			}
 			DefaultTableModel model = new DefaultTableModel(data, columnNames);
 			affinitytable = new JTable(model) {
 				private static final long serialVersionUID = 1L;
+				
 				@Override
-				public Class getColumnClass(int column) {
+				public Class<?> getColumnClass(int column) {
 					return Boolean.class;
 				}
 			};
@@ -294,7 +294,7 @@ public class Settings implements Activity {
 						cpuCores.setValue(count);
 				}
 			});
-			GridBagConstraints affinityContraints = new GridBagConstraints();			
+			GridBagConstraints affinityContraints = new GridBagConstraints();
 			affinityContraints.fill = GridBagConstraints.BOTH;
 			affinityContraints.weightx = 0.0;
 			affinityContraints.weighty = 0.0;
@@ -336,7 +336,6 @@ public class Settings implements Activity {
 		parent.addPadding(1, ++currentRow, columns - 2, 1);
 		parent.addPadding(0, 0, 1, currentRow + 1);
 		parent.addPadding(columns - 1, 0, 1, currentRow + 1);
-		
 		
 		if (haveAutoStarted == false && config.getAutoSignIn() && checkDisplaySaveButton()) {
 			// auto start
@@ -463,8 +462,8 @@ public class Settings implements Activity {
 			if (affinitytable != null) {
 				TableModel model = affinitytable.getModel();
 				BitSet bs = new BitSet(64);
-				for (int i=0;i<model.getColumnCount();i++) {
-					if ((Boolean)model.getValueAt(0, i) && i<64)
+				for (int i = 0; i < model.getColumnCount(); i++) {
+					if ((Boolean) model.getValueAt(0, i) && i < 64)
 						bs.set(i);
 				}
 				coreAffinity = Utils.convertBitset64ToLong(bs);
@@ -505,6 +504,7 @@ public class Settings implements Activity {
 	}
 	
 	class JCheckBoxGPU extends JCheckBox {
+		private static final long serialVersionUID = 1L;
 		private GPUDevice gpu;
 		
 		public JCheckBoxGPU(GPUDevice gpu) {


### PR DESCRIPTION


Each process started by the app can be scheduled to run on a specific core/processor. This is helpful for situation when the application runs in parallel with the other tasks.
Currently there are indeed to option : to use a percentage of cpu and schedule a task with priority : 'bellow normal'. In reality the blender app use 100% of the resources available so this approach is not always enough. The change add further improvements to this.

Tested on :+1:

    Windows 8.1
    Windows 10
    Linux red hat 6.3

For the convenience I added also a run target on the ant build leaving the existing client as a default one
