### PR TITLE
Do not report download for cached resources

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -533,21 +533,22 @@ public class Client {
 	}
 	
 	protected int downloadSceneFile(Job ajob_) {
-		this.gui.status("Downloading project");
-		return this.downloadFile(ajob_, ajob_.getSceneArchivePath(), ajob_.getSceneMD5(), String.format("%s?type=job&job=%s&revision=%s", this.server.getPage("download-archive"), ajob_.getId(), ajob_.getRevision()), "Downloading project %s %%");
+		return this.downloadFile(ajob_, ajob_.getSceneArchivePath(), ajob_.getSceneMD5(), String.format("%s?type=job&job=%s&revision=%s", this.server.getPage("download-archive"), ajob_.getId(), ajob_.getRevision()), "Downloading project %s %%", "project");
 	}
 	
 	protected int downloadExecutable(Job ajob) {
-		this.gui.status("Downloading renderer");
-		return this.downloadFile(ajob, ajob.getRendererArchivePath(), ajob.getRenderMd5(), String.format("%s?type=binary&job=%s", this.server.getPage("download-archive"), ajob.getId()), "Downloading renderer %s %%");
+		return this.downloadFile(ajob, ajob.getRendererArchivePath(), ajob.getRenderMd5(), String.format("%s?type=binary&job=%s", this.server.getPage("download-archive"), ajob.getId()), "Downloading renderer %s %%", "renderer");
 	}
 	
-	private int downloadFile(Job ajob, String local_path, String md5_server, String url, String update_ui) {
+	private int downloadFile(Job ajob, String local_path, String md5_server, String url, String update_ui, String download_type) {
 		File local_path_file = new File(local_path);
 		
 		if (local_path_file.exists() == true) {
+			this.gui.status("Reusing cached "+download_type);
 			return 0;
 		}
+		
+		this.gui.status("Downloading "+download_type);
 		
 		// must download the archive
 		int ret = this.server.HTTPGetFile(url, local_path, this.gui, update_ui);

--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -545,11 +545,11 @@ public class Client {
 		String update_ui = "Downloading " + download_type + " %s %%";
 		
 		if (local_path_file.exists() == true) {
-			this.gui.status("Reusing cached "+download_type);
+			this.gui.status("Reusing cached " + download_type);
 			return 0;
 		}
 		
-		this.gui.status("Downloading "+download_type);
+		this.gui.status("Downloading " + download_type);
 		
 		// must download the archive
 		int ret = this.server.HTTPGetFile(url, local_path, this.gui, update_ui);

--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -533,15 +533,16 @@ public class Client {
 	}
 	
 	protected int downloadSceneFile(Job ajob_) {
-		return this.downloadFile(ajob_, ajob_.getSceneArchivePath(), ajob_.getSceneMD5(), String.format("%s?type=job&job=%s&revision=%s", this.server.getPage("download-archive"), ajob_.getId(), ajob_.getRevision()), "Downloading project %s %%", "project");
+		return this.downloadFile(ajob_, ajob_.getSceneArchivePath(), ajob_.getSceneMD5(), String.format("%s?type=job&job=%s&revision=%s", this.server.getPage("download-archive"), ajob_.getId(), ajob_.getRevision()), "project");
 	}
 	
 	protected int downloadExecutable(Job ajob) {
-		return this.downloadFile(ajob, ajob.getRendererArchivePath(), ajob.getRenderMd5(), String.format("%s?type=binary&job=%s", this.server.getPage("download-archive"), ajob.getId()), "Downloading renderer %s %%", "renderer");
+		return this.downloadFile(ajob, ajob.getRendererArchivePath(), ajob.getRenderMd5(), String.format("%s?type=binary&job=%s", this.server.getPage("download-archive"), ajob.getId()), "renderer");
 	}
 	
-	private int downloadFile(Job ajob, String local_path, String md5_server, String url, String update_ui, String download_type) {
+	private int downloadFile(Job ajob, String local_path, String md5_server, String url, String download_type) {
 		File local_path_file = new File(local_path);
+		String update_ui = "Downloading " + download_type + " %s %%";
 		
 		if (local_path_file.exists() == true) {
 			this.gui.status("Reusing cached "+download_type);


### PR DESCRIPTION
Moves the UI update code into downloadFile(), after the check to see if
the file is already cached, to avoid reporting that the client is
downloading files when it isn't.

This always bugged me, and it seemed like an easy fix to make, so I figured I'd dust off Eclipse and give it a go. It's a relatively simple change, and seems to work as intended in my testing.

This change makes downloadFile() always report that it was called, whereas before it could be called silently. I considered adding some code to allow this in the future, but the download is always reported manually everywhere the function is used anyway, and I wanted to keep the commit simple, so I decided against it for now.