### PR TITLE
Show blend file name when starting render

### DIFF
--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -196,7 +196,7 @@ public class Job {
 	}
 	
 	public Error.Type render() {
-		gui.status("Rendering");
+		gui.status("Rendering file " + this.path);
 		RenderProcess process = getProcessRender();
 		String core_script = "import bpy\n" + "bpy.context.user_preferences.system.compute_device_type = \"%s\"\n" + "bpy.context.scene.cycles.device = \"%s\"\n" + "bpy.context.user_preferences.system.compute_device = \"%s\"\n";
 		if (getUseGPU() && config.getGPUDevice() != null) {


### PR DESCRIPTION
This commit is a fairly simple one that just shows the blend file name in the UI for the ~5 seconds it takes the renderer to start up.

I was actually hoping to display the project name instead of the blend file name, but that information isn't sent to the client. Do you think it would be possible to update `request_job.php` to include the project name in the response? Once this is done, it should be trivial to modify `Server.java` and `Job.java` to show it.

The reason I'm proposing this is that I think it would more effectively show people what they're helping with. As it is, the client doesn't really do much to show that off to the user, aside from a small thumbnail that often only displays a tile from a larger scene. I think giving users a better sense of what they're helping with might encourage them to render more, which is always nice.