### PR TITLE
Allow exit after frame for text and oneLine mode

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -233,6 +233,7 @@ public class Client {
 					Date wakeup_time = new Date(new Date().getTime() + time_sleep);
 					this.gui.status(String.format("No job available. Sleeping for 15 minutes (will wake up at ~%tR)", wakeup_time));
 					this.gui.framesRemaining(0);
+					this.suspended = true;
 					int time_slept = 0;
 					while (time_slept < time_sleep && this.running == true) {
 						try {
@@ -243,6 +244,7 @@ public class Client {
 						}
 						time_slept += 5000;
 					}
+					this.suspended = false;
 					continue; // go back to ask job
 				}
 				
@@ -342,6 +344,8 @@ public class Client {
 		}
 		
 		this.server = null;
+
+		this.gui.stop();
 		
 		return 0;
 	}
@@ -372,7 +376,7 @@ public class Client {
 	public boolean isRunning() {
 		return this.running;
 	}
-	
+
 	public int senderLoop() {
 		int step = log.newCheckPoint();
 		Error.Type ret;

--- a/src/com/sheepit/client/standalone/GuiText.java
+++ b/src/com/sheepit/client/standalone/GuiText.java
@@ -45,22 +45,25 @@ public class GuiText implements Gui {
 	public void start() {
 		if (client != null) {
 
-			Signal.handle(new Signal("INT"), signal -> {
-				sigIntCount++;
+			Signal.handle(new Signal("INT"), new SignalHandler() {
+				@Override
+				public void handle(Signal signal) {
+					sigIntCount++;
 
-				if (sigIntCount == 4) {
-					// This is only for ugly issues that might occur
-					System.out.println("WARNING: Hitting Ctrl-C again will force close the application.");
-				} else if (sigIntCount == 5) {
-					Signal.raise(new Signal("INT"));
-					Runtime.getRuntime().halt(0);
-				} else if (client.isRunning() && !client.isSuspended()) {
-                    client.askForStop();
-                    System.out.println("Will exit after current frame... Press Ctrl+C again to exit now.");
-                } else {
-					client.stop();
+					if (sigIntCount == 4) {
+						// This is only for ugly issues that might occur
+						System.out.println("WARNING: Hitting Ctrl-C again will force close the application.");
+					} else if (sigIntCount == 5) {
+						Signal.raise(new Signal("INT"));
+						Runtime.getRuntime().halt(0);
+					} else if (client.isRunning() && !client.isSuspended()) {
+						client.askForStop();
+						System.out.println("Will exit after current frame... Press Ctrl+C again to exit now.");
+					} else {
+						client.stop();
+					}
 				}
-            });
+			});
 
 			client.run();
 			client.stop();

--- a/src/com/sheepit/client/standalone/GuiTextOneLine.java
+++ b/src/com/sheepit/client/standalone/GuiTextOneLine.java
@@ -3,6 +3,7 @@ package com.sheepit.client.standalone;
 import com.sheepit.client.Client;
 import com.sheepit.client.Gui;
 import sun.misc.Signal;
+import sun.misc.SignalHandler;
 
 public class GuiTextOneLine implements Gui {
 	public static final String type = "oneLine";
@@ -29,17 +30,20 @@ public class GuiTextOneLine implements Gui {
 	public void start() {
 		if (client != null) {
 
-			Signal.handle(new Signal("INT"), signal -> {
-				sigIntCount++;
+			Signal.handle(new Signal("INT"), new SignalHandler() {
+				@Override
+				public void handle(Signal signal) {
+					sigIntCount++;
 
-				if (sigIntCount == 5) {
-					Signal.raise(new Signal("INT"));
-					Runtime.getRuntime().halt(0);
-				} else if (client.isRunning() && !client.isSuspended()) {
-					client.askForStop();
-					exiting = true;
-				} else {
-					client.stop();
+					if (sigIntCount == 5) {
+						Signal.raise(new Signal("INT"));
+						Runtime.getRuntime().halt(0);
+					} else if (client.isRunning() && !client.isSuspended()) {
+						client.askForStop();
+						exiting = true;
+					} else {
+						client.stop();
+					}
 				}
 			});
 

--- a/src/com/sheepit/client/standalone/GuiTextOneLine.java
+++ b/src/com/sheepit/client/standalone/GuiTextOneLine.java
@@ -2,14 +2,19 @@ package com.sheepit.client.standalone;
 
 import com.sheepit.client.Client;
 import com.sheepit.client.Gui;
+import sun.misc.Signal;
 
 public class GuiTextOneLine implements Gui {
 	public static final String type = "oneLine";
 	
 	private int rendered;
 	private int remaining;
+	private int sigIntCount = 0;
+
 	private String status;
 	private String line;
+
+	private boolean exiting = false;
 	
 	private Client client;
 	
@@ -23,6 +28,21 @@ public class GuiTextOneLine implements Gui {
 	@Override
 	public void start() {
 		if (client != null) {
+
+			Signal.handle(new Signal("INT"), signal -> {
+				sigIntCount++;
+
+				if (sigIntCount == 5) {
+					Signal.raise(new Signal("INT"));
+					Runtime.getRuntime().halt(0);
+				} else if (client.isRunning() && !client.isSuspended()) {
+					client.askForStop();
+					exiting = true;
+				} else {
+					client.stop();
+				}
+			});
+
 			client.run();
 			client.stop();
 		}
@@ -30,6 +50,7 @@ public class GuiTextOneLine implements Gui {
 	
 	@Override
 	public void stop() {
+		Runtime.getRuntime().halt(0);
 	}
 	
 	@Override
@@ -70,7 +91,7 @@ public class GuiTextOneLine implements Gui {
 		int charToRemove = line.length();
 		
 		System.out.print("\r");
-		line = String.format("Frames rendered: %d remaining: %d | %s", rendered, remaining, status);
+		line = String.format("Frames rendered: %d remaining: %d | %s", rendered, remaining, status) + (exiting ? " (Exiting after this frame)" : "");
 		System.out.print(line);
 		for (int i = line.length(); i <= charToRemove; i++) {
 			System.out.print(" ");


### PR DESCRIPTION
This allows users exiting after the current frame has been rendered while using the text or oneLine mode.

How it works:
If it's rendering, hit Ctrl-C to exit after the current frame (a message will appear in the console) (this is calling `client.askForStop()`.
Hitting Ctrl-C again will stop the client instantly (this is calling `client.stop()`).

If there should be problems with the client not exiting properly (because of uncatched exceptions etc.) I've built in an "emergency exit": Hitting Ctrl-C five times will force close the application instantly (But this should not be used because it won't remove temp files etc.).