### PR TITLE
fixed infinite wait on too large dmesg output

### DIFF
--- a/src/com/sheepit/client/os/FreeBSD.java
+++ b/src/com/sheepit/client/os/FreeBSD.java
@@ -53,7 +53,6 @@ public class FreeBSD extends OS {
 		try {
 			Runtime r = Runtime.getRuntime();
 			Process p = r.exec("dmesg");
-			p.waitFor();
 			BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
 			String line = "";
 			
@@ -94,7 +93,6 @@ public class FreeBSD extends OS {
 		try {
 			Runtime r = Runtime.getRuntime();
 			Process p = r.exec("dmesg");
-			p.waitFor();
 			BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
 			String line = "";
 			


### PR DESCRIPTION
I noticed that the client didn't start after a certain uptime of the FreeBSD machine. I was able to trace it back to an indefinite wait in the FreeBSD class, which was caused by two waitFor().

After the dmesg output reaches a certain size, the output buffer of the process fills up and waits for it to be read. Of course, it doesn't get read and the processes deadlock.

After further review I determined that the waitFor() calls are unnesseary and the code works fine without it.