### PR TITLE
fixed issues with dmesg being rotated

### DIFF
--- a/src/com/sheepit/client/os/FreeBSD.java
+++ b/src/com/sheepit/client/os/FreeBSD.java
@@ -31,11 +31,14 @@ import com.sheepit.client.hardware.cpu.CPU;
 
 public class FreeBSD extends OS {
 	private final String NICE_BINARY_PATH = "nice";
+	private final String CPUID_BINARY_PATH = "cpuid";
 	private Boolean hasNiceBinary;
+	private Boolean hasCpuIDBinary;
 	
 	public FreeBSD() {
 		super();
 		this.hasNiceBinary = null;
+		this.hasCpuIDBinary = null;
 	}
 	
 	public String name() {
@@ -50,62 +53,120 @@ public class FreeBSD extends OS {
 	@Override
 	public CPU getCPU() {
 		CPU ret = new CPU();
-		try {
-			Runtime r = Runtime.getRuntime();
-			Process p = r.exec("dmesg");
-			BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
-			String line = "";
-			
-			while ((line = b.readLine()) != null) {
-				if (line.startsWith("CPU:")) {
-					String buf[] = line.split(":");
-					if (buf.length > 1) {
-						ret.setName(buf[1].trim());
-					}
-				}
-				
-				if (line.contains("Family=") && line.contains("Model=")) {
-					String buf[] = line.split(" ");
-					for (int i = 0; i < buf.length; i++) {
-						if (buf[i].contains("Family")) {
-							String family = buf[i].split("=")[1];
-							ret.setFamily(family.split("x")[1]);
-						}
-						
-						if (buf[i].contains("Model")) {
-							String model = buf[i].split("=")[1];
-							ret.setModel(model.split("x")[1]);
+		if (this.hasCpuIDBinary == null) {
+			this.checkCpuIDAvailability();
+		}
+		
+		if (this.hasCpuIDBinary == true) {
+			try {
+				Runtime r = Runtime.getRuntime();
+				Process p = r.exec(CPUID_BINARY_PATH);
+				BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
+				String line = "";
+
+				while ((line = b.readLine()) != null) {
+					if (line.startsWith("Family")) {
+						String buf[] = line.split(" ");
+						if (buf.length > 1) {
+							ret.setFamily(buf[1].trim());
+						} else {
+							Log.getInstance(null).debug("Error while determining CPU family using cpuID, falling back to dmesg!");
+							this.hasCpuIDBinary = false;
 						}
 					}
+					if (line.startsWith("Model")) {
+						String buf[] = line.split(" ");
+						if (buf.length > 1) {
+							ret.setModel(buf[1].trim());
+						} else {
+							Log.getInstance(null).debug("Error while determining CPU model using cpuID, falling back to dmesg!");
+							this.hasCpuIDBinary = false;
+						}
+					}
+					if (line.startsWith("Extended brand string")) {
+						String buf[] = line.split("\"");
+						if (buf.length > 1) {
+							ret.setName(buf[1].trim());
+						} else {
+							Log.getInstance(null).debug("Error while determining CPU name using cpuID, falling back to dmesg!");
+							this.hasCpuIDBinary = false;
+						}
+					}
 				}
+				b.close();
+				if (! ret.haveData()) {
+					Log.getInstance(null).debug("Error while determining CPU info using cpuID, falling back to dmesg!");
+					this.hasCpuIDBinary = false;
+				}
+				if (this.hasCpuIDBinary == false) {
+					return this.getCPU();
+				}
+				return ret;
 			}
-			b.close();
-			return ret;
+			catch (Exception e) {
+				e.printStackTrace();
+			}
+		} else {
+			try {
+				Runtime r = Runtime.getRuntime();
+				Process p = r.exec("dmesg");
+				BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
+				String line = "";
+				
+				while ((line = b.readLine()) != null) {
+					if (line.startsWith("CPU:")) {
+						String buf[] = line.split(":");
+						if (buf.length > 1) {
+							ret.setName(buf[1].trim());
+						}
+					}
+					
+					if (line.contains("Family=") && line.contains("Model=")) {
+						String buf[] = line.split(" ");
+						for (int i = 0; i < buf.length; i++) {
+							if (buf[i].contains("Family")) {
+								String family = buf[i].split("=")[1];
+								ret.setFamily(family.split("x")[1]);
+							}
+							
+							if (buf[i].contains("Model")) {
+								String model = buf[i].split("=")[1];
+								ret.setModel(model.split("x")[1]);
+							}
+						}
+					}
+				}
+				b.close();
+				if (! ret.haveData()) {
+					Log.getInstance(null).debug("Error while determining CPU info; consider installing cpuID; setting dummy data!");
+					ret.setName("0");
+					ret.setModel("0");
+					ret.setFamily("0");
+				}
+				return ret;
+			}
+			catch (Exception e) {
+				e.printStackTrace();
+			}
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-		}
-		return ret;
+		return null;
 	}
 	
 	@Override
 	public int getMemory() {
 		try {
 			Runtime r = Runtime.getRuntime();
-			Process p = r.exec("dmesg");
+			Process p = r.exec("sysctl -n hw.usermem");
 			BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
 			String line = "";
 			
-			while ((line = b.readLine()) != null) {
-				if (line.startsWith("avail memory")) {
-					String buf[] = line.split(" ");
-					if (buf.length > 4) {
-						Long mem_byte = Long.parseLong(buf[3].trim());
-						return (int) (mem_byte / Long.valueOf(1024));
-					}
-				}
-			}
+			line = b.readLine();
 			b.close();
+			if (line == "") {
+				return 0;
+			}
+			Long mem_byte = Long.parseLong(line.trim());
+			return (int) (mem_byte / Long.valueOf(1024));
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -172,6 +233,26 @@ public class FreeBSD extends OS {
 		catch (IOException e) {
 			this.hasNiceBinary = false;
 			Log.getInstance(null).error("Failed to find low priority binary, will not launch renderer in normal priority (" + e + ")");
+		}
+		finally {
+			if (process != null) {
+				process.destroy();
+			}
+		}
+	}
+
+	private void checkCpuIDAvailability() {
+		ProcessBuilder builder = new ProcessBuilder();
+		builder.command(CPUID_BINARY_PATH);
+		builder.redirectErrorStream(true);
+		Process process = null;
+		try {
+			process = builder.start();
+			this.hasCpuIDBinary = true;
+		}
+		catch (IOException e) {
+			this.hasCpuIDBinary = false;
+			Log.getInstance(null).info("Could not find cpuID binary; trying dmesg fallback!");
 		}
 		finally {
 			if (process != null) {


### PR DESCRIPTION
Fix for #61.

This should fix the issue in any case.
First it tries to get the info from cpuid, if this doesn't work it tries dmesg.
If all these options fail, the values are set to "0".