### PR TITLE
create cache dir if not exists

### DIFF
--- a/src/com/sheepit/client/standalone/Worker.java
+++ b/src/com/sheepit/client/standalone/Worker.java
@@ -115,6 +115,7 @@ public class Worker {
 		
 		if (cache_dir != null) {
 			File a_dir = new File(cache_dir);
+			a_dir.mkdirs();
 			if (a_dir.isDirectory() && a_dir.canWrite()) {
 				config.setCacheDir(a_dir);
 			}


### PR DESCRIPTION
if a cache_dir is given as command line argument and it does not exist it will try to create it with it parents