### PR TITLE
Show compute method in user interface (CPU/GPU)

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -557,6 +557,7 @@ public class Client {
 		int ret;
 		
 		gui.setRenderingProjectName(ajob.getName());
+		gui.setComputeMethod(ajob.getUsingGPU() ? "GPU" : "CPU");
 		
 		try {
 			ret = this.downloadExecutable(ajob);
@@ -604,6 +605,7 @@ public class Client {
 		gui.setRenderingProjectName("");
 		gui.setRemainingTime("");
 		gui.setRenderingTime("");
+		gui.setComputeMethod("");
 		if (err != Error.Type.OK) {
 			this.log.error("Client::work problem with runRenderer (ret " + err + ")");
 			return err;

--- a/src/com/sheepit/client/Configuration.java
+++ b/src/com/sheepit/client/Configuration.java
@@ -195,6 +195,12 @@ public class Configuration {
 				this.workingDirectory.delete(); // hoho
 				this.workingDirectory.mkdir();
 				this.workingDirectory.deleteOnExit();
+				
+				// since there is no working directory and the client will be working in the system temp directory, 
+				// we can also set up a 'permanent' directory for immutable files (like renderer binary)
+				
+				this.storageDirectory = new File(this.workingDirectory.getParent() + File.separator + "sheepit_binary_cache");
+				this.storageDirectory.mkdir();
 			}
 			catch (IOException e) {
 				e.printStackTrace();

--- a/src/com/sheepit/client/Gui.java
+++ b/src/com/sheepit/client/Gui.java
@@ -39,6 +39,8 @@ public interface Gui {
 	public void AddFrameRendered();
 	
 	public void setClient(Client cli);
+
+	public void setComputeMethod(String computeMethod);
 	
 	public Client getClient();
 }

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -398,7 +398,7 @@ public class Job {
 			log.debug("Job::render been asked to end render");
 			
 			long duration = (new Date().getTime() - process.getStartTime() ) / 1000; // in seconds
-			if (config.getMaxRenderTime() != -1 &&  duration > config.getMaxRenderTime()) {
+			if (config.getMaxRenderTime() > 0 && duration > config.getMaxRenderTime()) {
 				log.debug("Render killed because process duration (" + duration + "s) is over user setting (" + config.getMaxRenderTime() + "s)");
 				return Error.Type.RENDERER_KILLED_BY_USER_OVER_TIME;
 			}

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -57,6 +57,7 @@ public class Job {
 	private String rendererCommand;
 	private String script;
 	private boolean useGPU;
+	private boolean usingGPU;  // used for the UI to tell what is actually being used to render the job
 	private String name;
 	private String password;
 	private String extras;
@@ -214,15 +215,20 @@ public class Job {
 	public String getSceneArchivePath() {
 		return config.workingDirectory.getAbsolutePath() + File.separator + sceneMD5 + ".zip";
 	}
-	
+
+	public boolean getUsingGPU()
+	{
+		return usingGPU;
+	}
+
 	public String getSceneArchivePassword() {
 		return password;
 	}
-	
+
 	public boolean simultaneousUploadIsAllowed() {
 		return synchronousUpload;
 	}
-	
+
 	public Error.Type render() {
 		gui.status("Rendering");
 		RenderProcess process = getProcessRender();
@@ -230,9 +236,11 @@ public class Job {
 		String core_script = "";
 		if (getUseGPU() && config.getGPUDevice() != null && config.getComputeMethod() != ComputeType.CPU) {
 			core_script = "sheepit_set_compute_device(\"CUDA\", \"GPU\", \"" + config.getGPUDevice().getCudaName() + "\")\n";
+			usingGPU = true;
 		}
 		else {
 			core_script = "sheepit_set_compute_device(\"NONE\", \"CPU\", \"CPU\")\n";
+			usingGPU = false;
 		}
 		core_script += String.format("bpy.context.scene.render.tile_x = %1$d\nbpy.context.scene.render.tile_y = %1$d\n", getTileSize());
 		File script_file = null;

--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -119,7 +119,7 @@ public class GuiSwing extends JFrame implements Gui {
 		}
 		
 		setTitle("SheepIt Render Farm");
-		setSize(520, 640);
+		setSize(520, 660);
 		
 		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		

--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -27,6 +27,10 @@ import java.awt.PopupMenu;
 import java.awt.SystemTray;
 import java.awt.Toolkit;
 import java.awt.TrayIcon;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowStateListener;
 import java.net.URL;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -90,12 +94,17 @@ public class GuiSwing extends JFrame implements Gui {
 			try {
 				sysTray = SystemTray.getSystemTray();
 				if (SystemTray.isSupported()) {
-					addWindowStateListener(e ->
+					addWindowStateListener(new WindowStateListener()
 					{
-                        if (e.getNewState() == ICONIFIED) {
-                            hideToTray();
-                        }
-                    });
+						@Override
+						public void windowStateChanged(WindowEvent e)
+						{
+							if (e.getNewState() == ICONIFIED)
+							{
+								GuiSwing.this.hideToTray();
+							}
+						}
+					});
 				}
 			}
 			catch (UnsupportedOperationException e) {
@@ -282,26 +291,51 @@ public class GuiSwing extends JFrame implements Gui {
 		final TrayIcon icon = new TrayIcon(img);
 		
 		MenuItem exit = new MenuItem("Exit");
-		exit.addActionListener(e -> System.exit(0));
+		exit.addActionListener(new ActionListener()
+		{
+			@Override
+			public void actionPerformed(ActionEvent e)
+			{
+				System.exit(0);
+			}
+		});
 		trayMenu.add(exit);
 		
 		MenuItem open = new MenuItem("Open...");
-		open.addActionListener(e -> restoreFromTray());
+		open.addActionListener(new ActionListener()
+		{
+			@Override
+			public void actionPerformed(ActionEvent e)
+			{
+				GuiSwing.this.restoreFromTray();
+			}
+		});
 		trayMenu.add(open);
 		
 		MenuItem settings = new MenuItem("Settings...");
-		settings.addActionListener(e ->
+		settings.addActionListener(new ActionListener()
 		{
-            restoreFromTray();
-            showActivity(ActivityType.SETTINGS);
-        });
+			@Override
+			public void actionPerformed(ActionEvent e)
+			{
+				GuiSwing.this.restoreFromTray();
+				GuiSwing.this.showActivity(ActivityType.SETTINGS);
+			}
+		});
 		trayMenu.add(settings);
 		
 		icon.setPopupMenu(trayMenu);
 		icon.setImageAutoSize(true);
 		icon.setToolTip("SheepIt! Client");
 		
-		icon.addActionListener(e -> restoreFromTray());
+		icon.addActionListener(new ActionListener()
+		{
+			@Override
+			public void actionPerformed(ActionEvent e)
+			{
+				GuiSwing.this.restoreFromTray();
+			}
+		});
 		
 		return icon;
 		

--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -27,19 +27,11 @@ import java.awt.PopupMenu;
 import java.awt.SystemTray;
 import java.awt.Toolkit;
 import java.awt.TrayIcon;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.WindowEvent;
-import java.awt.event.WindowStateListener;
 import java.net.URL;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import javax.swing.ImageIcon;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 
 import com.sheepit.client.Client;
@@ -98,13 +90,12 @@ public class GuiSwing extends JFrame implements Gui {
 			try {
 				sysTray = SystemTray.getSystemTray();
 				if (SystemTray.isSupported()) {
-					addWindowStateListener(new WindowStateListener() {
-						public void windowStateChanged(WindowEvent e) {
-							if (e.getNewState() == ICONIFIED) {
-								hideToTray();
-							}
-						}
-					});
+					addWindowStateListener(e ->
+					{
+                        if (e.getNewState() == ICONIFIED) {
+                            hideToTray();
+                        }
+                    });
 				}
 			}
 			catch (UnsupportedOperationException e) {
@@ -121,7 +112,7 @@ public class GuiSwing extends JFrame implements Gui {
 		setTitle("SheepIt Render Farm");
 		setSize(520, 660);
 		
-		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 		
 		panel = new JPanel();
 		panel.setLayout(new GridBagLayout());
@@ -225,7 +216,7 @@ public class GuiSwing extends JFrame implements Gui {
 			notifyAll();
 		}
 		
-		if (threadClient == null || threadClient.isAlive() == false) {
+		if (threadClient == null || !threadClient.isAlive()) {
 			threadClient = new ThreadClient();
 			threadClient.start();
 		}
@@ -249,7 +240,7 @@ public class GuiSwing extends JFrame implements Gui {
 	}
 	
 	public void hideToTray() {
-		if (sysTray == null || SystemTray.isSupported() == false) {
+		if (sysTray == null || !SystemTray.isSupported()) {
 			System.out.println("GuiSwing::hideToTray SystemTray not supported!");
 			return;
 		}
@@ -271,7 +262,7 @@ public class GuiSwing extends JFrame implements Gui {
 		if (sysTray != null && SystemTray.isSupported()) {
 			sysTray.remove(trayIcon);
 			setVisible(true);
-			setExtendedState(getExtendedState() & ~JFrame.ICONIFIED & JFrame.NORMAL); // for toFront and requestFocus to actually work
+			setExtendedState(0); // for toFront and requestFocus to actually work
 			toFront();
 			requestFocus();
 		}
@@ -285,43 +276,26 @@ public class GuiSwing extends JFrame implements Gui {
 		final TrayIcon icon = new TrayIcon(img);
 		
 		MenuItem exit = new MenuItem("Exit");
-		exit.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				System.exit(0);
-			}
-		});
+		exit.addActionListener(e -> System.exit(0));
 		trayMenu.add(exit);
 		
 		MenuItem open = new MenuItem("Open...");
-		open.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				restoreFromTray();
-			}
-		});
+		open.addActionListener(e -> restoreFromTray());
 		trayMenu.add(open);
 		
 		MenuItem settings = new MenuItem("Settings...");
-		settings.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				restoreFromTray();
-				showActivity(ActivityType.SETTINGS);
-			}
-		});
+		settings.addActionListener(e ->
+		{
+            restoreFromTray();
+            showActivity(ActivityType.SETTINGS);
+        });
 		trayMenu.add(settings);
 		
 		icon.setPopupMenu(trayMenu);
 		icon.setImageAutoSize(true);
 		icon.setToolTip("SheepIt! Client");
 		
-		icon.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				restoreFromTray();
-			}
-		});
+		icon.addActionListener(e -> restoreFromTray());
 		
 		return icon;
 		

--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -54,7 +54,7 @@ public class GuiSwing extends JFrame implements Gui {
 	private Settings activitySettings;
 	private TrayIcon trayIcon;
 	private boolean useSysTray;
-	
+
 	private int framesRendered;
 	
 	private boolean waitingForAuthentication;
@@ -202,7 +202,13 @@ public class GuiSwing extends JFrame implements Gui {
 	public void setClient(Client cli) {
 		client = cli;
 	}
-	
+
+	@Override
+	public void setComputeMethod(String computeMethod)
+	{
+		this.activityWorking.setComputeMethod(computeMethod);
+	}
+
 	public Configuration getConfiguration() {
 		return client.getConfiguration();
 	}

--- a/src/com/sheepit/client/standalone/GuiText.java
+++ b/src/com/sheepit/client/standalone/GuiText.java
@@ -134,7 +134,13 @@ public class GuiText implements Gui {
 	public void setClient(Client cli) {
 		client = cli;
 	}
-	
+
+	@Override
+	public void setComputeMethod(String computeMethod)
+	{
+		System.out.println("Compute method: " + computeMethod);
+	}
+
 	@Override
 	public Client getClient() {
 		return client;

--- a/src/com/sheepit/client/standalone/GuiTextOneLine.java
+++ b/src/com/sheepit/client/standalone/GuiTextOneLine.java
@@ -145,7 +145,13 @@ public class GuiTextOneLine implements Gui {
 	public void setClient(Client cli) {
 		client = cli;
 	}
-	
+
+	@Override
+	public void setComputeMethod(String computeMethod)
+	{
+		System.out.println("Compute method: " + computeMethod);
+	}
+
 	@Override
 	public Client getClient() {
 		return client;

--- a/src/com/sheepit/client/standalone/swing/activity/Working.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Working.java
@@ -102,7 +102,8 @@ public class Working implements Activity {
 		JLabel current_project_name = new JLabel("Name: ", JLabel.TRAILING);
 		JLabel current_project_duration = new JLabel("Rendering for: ", JLabel.TRAILING);
 		JLabel current_project_progression = new JLabel("Remaining: ", JLabel.TRAILING);
-		
+		JLabel computeMethodLabel = new JLabel("Compute method: ", JLabel.TRAILING);
+
 		current_project_panel.add(current_project_status);
 		current_project_panel.add(statusContent);
 		
@@ -114,6 +115,9 @@ public class Working implements Activity {
 		
 		current_project_panel.add(current_project_progression);
 		current_project_panel.add(currrent_project_progression_value);
+
+		current_project_panel.add(computeMethodLabel);
+		current_project_panel.add(computeMethod);
 		
 		// user info
 		JPanel session_info_panel = new JPanel(new SpringLayout());
@@ -122,8 +126,7 @@ public class Working implements Activity {
 		JLabel user_info_credits_this_session = new JLabel("Points earned: ", JLabel.TRAILING);
 		JLabel user_info_total_rendertime_this_session = new JLabel("Duration: ", JLabel.TRAILING);
 		JLabel user_info_rendered_frame_this_session = new JLabel("Rendered frames: ", JLabel.TRAILING);
-		JLabel computeMethodLabel = new JLabel("Compute method: ", JLabel.TRAILING);
-		
+
 		session_info_panel.add(user_info_credits_this_session);
 		session_info_panel.add(creditEarned);
 		
@@ -133,9 +136,6 @@ public class Working implements Activity {
 		session_info_panel.add(user_info_total_rendertime_this_session);
 		session_info_panel.add(user_info_total_rendertime_this_session_value);
 
-		session_info_panel.add(computeMethodLabel);
-		session_info_panel.add(computeMethod);
-		
 		// global stats
 		JPanel global_stats_panel = new JPanel(new SpringLayout());
 		global_stats_panel.setBorder(BorderFactory.createTitledBorder("Global stats"));
@@ -211,9 +211,9 @@ public class Working implements Activity {
 		Spring widthLeftColumn = getBestWidth(current_project_panel, 4, 2);
 		widthLeftColumn = Spring.max(widthLeftColumn, getBestWidth(global_stats_panel, 4, 2));
 		widthLeftColumn = Spring.max(widthLeftColumn, getBestWidth(session_info_panel, 3, 2));
-		alignPanel(current_project_panel, 4, 2, widthLeftColumn);
+		alignPanel(current_project_panel, 5, 2, widthLeftColumn);
 		alignPanel(global_stats_panel, 4, 2, widthLeftColumn);
-		alignPanel(session_info_panel, 4, 2, widthLeftColumn);
+		alignPanel(session_info_panel, 3, 2, widthLeftColumn);
 	}
 	
 	public void setStatus(String msg_) {

--- a/src/com/sheepit/client/standalone/swing/activity/Working.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Working.java
@@ -54,23 +54,24 @@ import com.sheepit.client.standalone.GuiSwing;
 import com.sheepit.client.standalone.GuiSwing.ActivityType;
 
 public class Working implements Activity {
-	GuiSwing parent;
+	private GuiSwing parent;
 	
-	JLabel statusContent;
-	JLabel renderedFrameContent;
-	JLabel remainingFrameContent;
-	JLabel lastRenderTime;
-	JLabel lastRender;
-	JLabel creditEarned;
-	JButton pauseButton;
-	JButton exitAfterFrame;
-	JLabel current_project_name_value;
-	JLabel current_project_duration_value;
-	JLabel currrent_project_progression_value;
-	JLabel user_info_points_total_value;
-	JLabel waiting_projects_value;
-	JLabel connected_machines_value;
-	JLabel user_info_total_rendertime_this_session_value;
+	private JLabel statusContent;
+	private JLabel renderedFrameContent;
+	private JLabel remainingFrameContent;
+	private JLabel lastRenderTime;
+	private JLabel lastRender;
+	private JLabel creditEarned;
+	private JButton pauseButton;
+	private JButton exitAfterFrame;
+	private JLabel current_project_name_value;
+	private JLabel current_project_duration_value;
+	private JLabel currrent_project_progression_value;
+	private JLabel user_info_points_total_value;
+	private JLabel waiting_projects_value;
+	private JLabel connected_machines_value;
+	private JLabel user_info_total_rendertime_this_session_value;
+	private JLabel computeMethod;
 	
 	public Working(GuiSwing parent_) {
 		parent = parent_;
@@ -88,6 +89,7 @@ public class Working implements Activity {
 		user_info_total_rendertime_this_session_value = new JLabel("");
 		lastRenderTime = new JLabel("");
 		lastRender = new JLabel("");
+		computeMethod = new JLabel("");
 	}
 	
 	@Override
@@ -120,6 +122,7 @@ public class Working implements Activity {
 		JLabel user_info_credits_this_session = new JLabel("Points earned: ", JLabel.TRAILING);
 		JLabel user_info_total_rendertime_this_session = new JLabel("Duration: ", JLabel.TRAILING);
 		JLabel user_info_rendered_frame_this_session = new JLabel("Rendered frames: ", JLabel.TRAILING);
+		JLabel computeMethodLabel = new JLabel("Compute method: ", JLabel.TRAILING);
 		
 		session_info_panel.add(user_info_credits_this_session);
 		session_info_panel.add(creditEarned);
@@ -129,6 +132,9 @@ public class Working implements Activity {
 		
 		session_info_panel.add(user_info_total_rendertime_this_session);
 		session_info_panel.add(user_info_total_rendertime_this_session_value);
+
+		session_info_panel.add(computeMethodLabel);
+		session_info_panel.add(computeMethod);
 		
 		// global stats
 		JPanel global_stats_panel = new JPanel(new SpringLayout());
@@ -207,7 +213,7 @@ public class Working implements Activity {
 		widthLeftColumn = Spring.max(widthLeftColumn, getBestWidth(session_info_panel, 3, 2));
 		alignPanel(current_project_panel, 4, 2, widthLeftColumn);
 		alignPanel(global_stats_panel, 4, 2, widthLeftColumn);
-		alignPanel(session_info_panel, 3, 2, widthLeftColumn);
+		alignPanel(session_info_panel, 4, 2, widthLeftColumn);
 	}
 	
 	public void setStatus(String msg_) {
@@ -225,7 +231,12 @@ public class Working implements Activity {
 	public void setRenderingTime(String time_) {
 		current_project_duration_value.setText("<html>" + time_ + "</html>");
 	}
-	
+
+	public void setComputeMethod(String computeMethod)
+	{
+		this.computeMethod.setText(computeMethod);
+	}
+
 	public void displayStats(Stats stats) {
 		DecimalFormat df = new DecimalFormat("##,##,##,##,##,##,##0");
 		remainingFrameContent.setText(df.format(stats.getRemainingFrame()));


### PR DESCRIPTION
This is in response to the feature request [here](https://github.com/laurent-clouet/sheepit-client/issues/119).

> It would be great if there'd be an indication in the client whether the current project is rendered on the CPU or GPU.

I added a compute method to the UI in the project info section.

<img width="520" alt="sheepit_proj" src="https://cloud.githubusercontent.com/assets/20780097/25743452/7bbec6a0-3162-11e7-8625-6d1b009e87b3.png">
