### PR TITLE
fix ZipException: java.lang.IllegalArgumentException: Negative time

### DIFF
--- a/src/com/sheepit/client/Utils.java
+++ b/src/com/sheepit/client/Utils.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
 
 import javax.xml.bind.DatatypeConverter;
 
+import net.lingala.zip4j.model.UnzipParameters;
 import net.lingala.zip4j.core.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 
@@ -51,11 +52,13 @@ public class Utils {
 	public static int unzipFileIntoDirectory(String zipFileName_, String destinationDirectory, String password) throws FermeExceptionNoSpaceLeftOnDevice {
 		try {
 			ZipFile zipFile = new ZipFile(zipFileName_);
+			UnzipParameters unzipParameters = new UnzipParameters();
+			unzipParameters.setIgnoreDateTimeAttributes(true);
 			
 			if (password != null && zipFile.isEncrypted()) {
 				zipFile.setPassword(password);
 			}
-			zipFile.extractAll(destinationDirectory);
+			zipFile.extractAll(destinationDirectory, unzipParameters);
 		}
 		catch (ZipException e) {
 			e.printStackTrace();


### PR DESCRIPTION
fixes 
```
net.lingala.zip4j.exception.ZipException: net.lingala.zip4j.exception.ZipException: java.lang.IllegalArgumentException: Negative time
        at net.lingala.zip4j.unzip.Unzip.initExtractFile(Unzip.java:163)
        at net.lingala.zip4j.unzip.Unzip.initExtractAll(Unzip.java:83)
        at net.lingala.zip4j.unzip.Unzip.extractAll(Unzip.java:73)
        at net.lingala.zip4j.core.ZipFile.extractAll(ZipFile.java:488)
```
by instructing zip4j to ignore the modified date while extracting files.

ref: https://www.sheepit-renderfarm.com/forum/viewtopic.php?f=5&t=1142