### PR TITLE
make the GUI scrollable when needed

### DIFF
--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -20,6 +20,7 @@
 package com.sheepit.client.standalone;
 
 import java.awt.AWTException;
+import java.awt.Container;
 import java.awt.GridBagLayout;
 import java.awt.Image;
 import java.awt.MenuItem;
@@ -38,6 +39,7 @@ import java.util.TimerTask;
 import javax.swing.ImageIcon;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.border.EmptyBorder;
@@ -58,6 +60,7 @@ public class GuiSwing extends JFrame implements Gui {
 	
 	private SystemTray sysTray;
 	private JPanel panel;
+	private JScrollPane scrollPane;
 	private Working activityWorking;
 	private Settings activitySettings;
 	private TrayIcon trayIcon;
@@ -125,7 +128,8 @@ public class GuiSwing extends JFrame implements Gui {
 		
 		panel = new JPanel();
 		panel.setLayout(new GridBagLayout());
-		setContentPane(this.panel);
+		scrollPane = new JScrollPane(panel);
+		setContentPane(this.scrollPane);
 		panel.setBorder(new EmptyBorder(20, 20, 20, 20));
 		
 		activityWorking = new Working(this);
@@ -332,6 +336,11 @@ public class GuiSwing extends JFrame implements Gui {
 		
 	}
 	
+	@Override
+	public Container getContentPane() {
+		return panel;
+	}
+
 	public class ThreadClient extends Thread {
 		@Override
 		public void run() {


### PR DESCRIPTION
This PR uses a JSrollPane as root pane, instead of the previous JPanel, which is now the JScrollPane's child.
This should (provisionally) fix #149 .

![java_2018-06-01_15-48-18](https://user-images.githubusercontent.com/22377202/40844131-68d17e58-65b3-11e8-81ca-3fcbf0be02b3.png)
