### PR TITLE
Fix #154 - Illegal Reflective Access

### DIFF
--- a/src/com/sheepit/client/os/windows/WinProcess.java
+++ b/src/com/sheepit/client/os/windows/WinProcess.java
@@ -61,35 +61,67 @@ public class WinProcess {
 		}
 	}
 	
-	public WinProcess(Process process) {
-		this();
+	private static boolean processHasGetPid () {
 		try {
-			Field f = process.getClass().getDeclaredField("handle");
-			f.setAccessible(true);
-			long val = f.getLong(process);
-			this.handle = new WinNT.HANDLE();
-			this.handle.setPointer(Pointer.createConstant(val));
-			this.pid = Kernel32.INSTANCE.GetProcessId(this.handle);
+			if (Process.class.getMethod("pid", (Class<?>)null) != null) {
+				return true;
+			}
+		} catch (NoSuchMethodException | SecurityException e) {
 		}
-		catch (NoSuchFieldException e) {
-		}
-		catch (IllegalArgumentException e) {
-		}
-		catch (IllegalAccessException e) {
-		}
+		return false;
 	}
-	
-	public WinProcess(int pid_) throws IOException {
-		this();
-		this.handle = Kernel32.INSTANCE.OpenProcess(0x0400 | // PROCESS_QUERY_INFORMATION
+
+	private static long getPid (Process process) {
+		try {
+			return (long)Process.class.getMethod("pid", (Class<?>)null).invoke(process, null);
+		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+			| SecurityException e) {
+		}
+		return 0;
+	}
+
+	private static WinNT.HANDLE getHandleByPid (int pid_) throws IOException {
+		WinNT.HANDLE handle = Kernel32.INSTANCE.OpenProcess(
+			0x0400 | // PROCESS_QUERY_INFORMATION
 				0x0800 | // PROCESS_SUSPEND_RESUME
 				0x0001 | // PROCESS_TERMINATE
 				0x0200 | // PROCESS_SET_INFORMATION
 				0x00100000, // SYNCHRONIZE
-				false, pid_);
-		if (this.handle == null) {
-			throw new IOException("OpenProcess failed: " + Kernel32Util.formatMessageFromLastErrorCode(Kernel32.INSTANCE.GetLastError()) + " (pid: " + pid_ + ")");
+			false, pid_);
+		if (handle == null) {
+			throw new IOException("OpenProcess failed: "
+				+ Kernel32Util.formatMessageFromLastErrorCode(Kernel32.INSTANCE.GetLastError()) + " (pid: " + pid_ + ")");
 		}
+		return handle;
+	}
+
+	public WinProcess (Process process)  {
+		this();
+		if (processHasGetPid()) {
+			int _pid = (int)getPid(process);
+			try {
+				this.handle = getHandleByPid(_pid);
+			} catch (IOException e) {
+			}
+			this.pid = _pid;
+		} else {
+			try {
+				Field f = process.getClass().getDeclaredField("handle");
+				f.setAccessible(true);
+				long val = f.getLong(process);
+				this.handle = new WinNT.HANDLE();
+				this.handle.setPointer(Pointer.createConstant(val));
+				this.pid = Kernel32.INSTANCE.GetProcessId(this.handle);
+			} catch (NoSuchFieldException e) {
+			} catch (IllegalArgumentException e) {
+			} catch (IllegalAccessException e) {
+			}
+		}
+	}
+
+	public WinProcess (int pid_) throws IOException {
+		this();
+		this.handle = getHandleByPid(pid_);
 		this.pid = pid_;
 	}
 	


### PR DESCRIPTION
Use Process's pid() when it exists.
(Done via reflection so it also works for java versions < 9)
Else fall back to old reflective method.