### PR TITLE
Make config file loader take ram in MB for consistency

### DIFF
--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -84,7 +84,7 @@ public class SettingsLoader {
 			cores = String.valueOf(cores_);
 		}
 		if (maxRam_ > 0) {
-			ram = String.valueOf(maxRam_);
+			ram = String.valueOf(maxRam_ * 1000);
 		}
 		if (maxRenderTime_ > 0) {
 			renderTime = String.valueOf(maxRenderTime_);


### PR DESCRIPTION
When passed as inline parameters, memory is expressed as MB. However, when passed in a config file, memory was expressed as KB. This created confusion among users.

This does break backwards compatibility, so merge with caution.

Ideally, a unit could be added to the parameter such as '1000000K' = '1000M' = '1G', making the default unit whatever it was before, but I'll save this for a future PR.