### PR TITLE
Specify Build to eliminate inconsistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ script: ant
 
 os:
   - linux
+dist: trusty
 
 # safelist
 branches:


### PR DESCRIPTION
Failing on xenial because of missing ant. Change to Trusty build as previously it was defaulted to.
Discussed in issue #185