### PR TITLE
Corrected HTTP Method Usage for Later JDK Versions

### DIFF
--- a/src/com/sheepit/proxy/Proxy.java
+++ b/src/com/sheepit/proxy/Proxy.java
@@ -151,7 +151,7 @@ class Proxy extends AbstractHandler implements HostnameVerifier, X509TrustManage
 		if (requestFromClient.getContentType() != null) {
 			request.setRequestProperty("Content-type", requestFromClient.getContentType());
 		}
-		request.setRequestMethod(requestFromClient.getMethod());
+		request.setRequestProperty("X-HTTP-Method-Override", requestFromClient.getMethod());
 		
 		Cookie[] cookies = requestFromClient.getCookies();
 		if (cookies != null) {


### PR DESCRIPTION
In later versions of JDK, non-standard HTTP methods are disallowed to prevent arbitrarily long request strings for security purposes (see: https://bugs.openjdk.java.net/browse/JDK-7016595 ). To correct this, X-HTTP-Method-Override is used to allow the CONNECT method to work properly.

This workaround requires the receiving server to correctly understand POST and X-HTTP-Method-Override, and cleaner workarounds do exist, however our server understands these properly so this workaround should be acceptable.