### PR TITLE
fix: typo when displaying time strings

### DIFF
--- a/src/com/sheepit/client/Utils.java
+++ b/src/com/sheepit/client/Utils.java
@@ -192,10 +192,10 @@ public class Utils {
 		
 		String output = "";
 		if (hours > 0) {
-			output += hours + "h";
+			output += hours + "h ";
 		}
 		if (minutes > 0) {
-			output += minutes + "min";
+			output += minutes + "min ";
 		}
 		if (seconds > 0) {
 			output += seconds + "s";


### PR DESCRIPTION
Fixed a typo where, when displaying a time (elapsed time, remaining time), the time is shown without any spaces between the hours, minutes and seconds (ie 1h24min4s). 
The correct format should be 1h 24min 4s.