### PR TITLE
v6/fix: typo when showing time values in client

### DIFF
--- a/src/com/sheepit/client/Utils.java
+++ b/src/com/sheepit/client/Utils.java
@@ -192,10 +192,10 @@ public class Utils {
 		
 		String output = "";
 		if (hours > 0) {
-			output += hours + "h";
+			output += hours + "h ";
 		}
 		if (minutes > 0) {
-			output += minutes + "min";
+			output += minutes + "min ";
 		}
 		if (seconds > 0) {
 			output += seconds + "s";


### PR DESCRIPTION
When displaying a time (elapsed time, remaining time) the hours, minutes and seconds aren't separated by a space character. The time is incorrectly shown like 1h24min4s instead of 1h 24min 4s.