### PR TITLE
Fix: background frame uploads not queuing properly

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -323,7 +323,7 @@ public class Client {
 					continue;
 				}
 				
-				if (this.renderingJob.isSynchronousUpload() == false) { // power or compute_method job, need to upload right away
+				if (this.renderingJob.isSynchronousUpload() == true) { // power or compute_method job, need to upload right away
 					ret = confirmJob(this.renderingJob);
 					if (ret != Error.Type.OK) {
 						gui.error("Client::run problem with confirmJob (returned " + ret + ")");


### PR DESCRIPTION
The upload process was not correctly queuing completed frames. As a result, a new job request was only triggered when the previous frame upload was finished (not immediately by using the existing background upload process).

Fixed the sync/async detection routine to ensure that handle the frames according to server specs. 

Additionally, in agreement with @laurent-clouet, removed the _-max-uploading-job_ inline option. Therefore, background upload is now enabled by default.