### PR TITLE
feature: improve user information on queued uploads

### DIFF
--- a/src/com/sheepit/client/Gui.java
+++ b/src/com/sheepit/client/Gui.java
@@ -36,6 +36,8 @@ public interface Gui {
 	
 	public void displayStats(Stats stats);
 	
+	public void displayUploadQueueStats(int queueSize, long queueVolume);
+	
 	public void error(String err_);
 	
 	public void AddFrameRendered();

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -64,6 +64,7 @@ public class Job {
 	private String rendererMD5;
 	private String id;
 	private String outputImagePath;
+	private long   outputImageSize;
 	private String path; // path inside of the archive
 	private String rendererCommand;
 	private String validationUrl;
@@ -98,6 +99,7 @@ public class Job {
 		synchronousUpload = synchronous_upload_;
 		gui = gui_;
 		outputImagePath = null;
+		outputImageSize = 0;
 		script = script_;
 		updateRenderingStatusMethod = update_method_;
 		askForRendererKill = false;
@@ -412,7 +414,8 @@ public class Job {
 		}
 		else {
 			setOutputImagePath(files[0].getAbsolutePath());
-			log.debug("Job::render pictureFilename: '" + getOutputImagePath() + "'");
+			this.outputImageSize = new File(getOutputImagePath()).length();
+			log.debug(String.format("Job::render pictureFilename: %s, size: %d'",getOutputImagePath(), this.outputImageSize));
 		}
 		
 		File scene_dir = new File(getSceneDirectory());

--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -238,6 +238,13 @@ public class GuiSwing extends JFrame implements Gui {
 	}
 	
 	@Override
+	public void displayUploadQueueStats(int queueSize, long queueVolume) {
+		if (activityWorking != null) {
+			this.activityWorking.displayUploadQueueStats(queueSize, queueVolume);
+		}
+	}
+	
+	@Override
 	public Client getClient() {
 		return client;
 	}

--- a/src/com/sheepit/client/standalone/GuiText.java
+++ b/src/com/sheepit/client/standalone/GuiText.java
@@ -119,7 +119,11 @@ public class GuiText implements Gui {
 	
 	@Override
 	public void displayUploadQueueStats(int queueSize, long queueVolume) {
-		System.out.println(String.format("Upload queue size / volume: %d / %.2fMB", queueSize, (queueVolume / 1024.0 / 1024.0)));
+		// No need to check if the queue is not empty to show the volume bc this line is always shown at the end
+		// of the render process in text GUI (unless an error occurred, where the file is uploaded synchronously)
+		System.out.println(String.format("Queued uploads: %d (%.2fMB)",
+				queueSize,
+				(queueVolume / 1024.0 / 1024.0)));
 	}
 	
 	@Override

--- a/src/com/sheepit/client/standalone/GuiText.java
+++ b/src/com/sheepit/client/standalone/GuiText.java
@@ -118,6 +118,11 @@ public class GuiText implements Gui {
 	}
 	
 	@Override
+	public void displayUploadQueueStats(int queueSize, long queueVolume) {
+		System.out.println(String.format("Upload queue size / volume: %d / %.2fMB", queueSize, (queueVolume / 1024.0 / 1024.0)));
+	}
+	
+	@Override
 	public void setRenderingProjectName(String name_) {
 		if (name_ != null && name_.isEmpty() == false) {
 			System.out.println("Rendering project \"" + name_ + "\"");

--- a/src/com/sheepit/client/standalone/GuiTextOneLine.java
+++ b/src/com/sheepit/client/standalone/GuiTextOneLine.java
@@ -42,6 +42,9 @@ public class GuiTextOneLine implements Gui {
 	private String status;
 	private String line;
 	
+	private int  uploadQueueSize;
+	private long uploadQueueVolume;
+	
 	private boolean exiting = false;
 	
 	private Client client;
@@ -54,6 +57,8 @@ public class GuiTextOneLine implements Gui {
 		status = "";
 		computeMethod = "";
 		line = "";
+		uploadQueueSize   = 0;
+		uploadQueueVolume = 0;
 	}
 	
 	@Override
@@ -136,6 +141,12 @@ public class GuiTextOneLine implements Gui {
 	}
 	
 	@Override
+	public void displayUploadQueueStats(int queueSize, long queueVolume) {
+		this.uploadQueueSize   = queueSize;
+		this.uploadQueueVolume = queueVolume;
+	}
+	
+	@Override
 	public void setRemainingTime(String time_) {
 		status = "(remaining " + time_ + ")";
 		updateLine();
@@ -171,7 +182,17 @@ public class GuiTextOneLine implements Gui {
 		int charToRemove = line.length();
 		
 		System.out.print("\r");
-		line = String.format("Frames: %d Points: %s | %s %s %s", rendered, creditsEarned != null ? creditsEarned : "unknown", project, computeMethod, status + (exiting ? " (Exiting after this frame)" : ""));
+		
+		line = String.format("Frames: %d Points: %s | %s%s %s %s",
+				rendered,
+				creditsEarned != null ? creditsEarned : "unknown",
+				(this.uploadQueueSize > 0 ? String.format("Upload queue: %d (%.2fMB) | ",
+						this.uploadQueueSize, (this.uploadQueueVolume / 1024.0 / 1024.0)) : ""),
+				project,
+				computeMethod,
+				status + (exiting ? " (Exiting after all frames are uploaded)" : "")
+		);
+		
 		System.out.print(line);
 		for (int i = line.length(); i <= charToRemove; i++) {
 			System.out.print(" ");

--- a/src/com/sheepit/client/standalone/GuiTextOneLine.java
+++ b/src/com/sheepit/client/standalone/GuiTextOneLine.java
@@ -183,11 +183,11 @@ public class GuiTextOneLine implements Gui {
 		
 		System.out.print("\r");
 		
-		line = String.format("Frames: %d Points: %s | %s%s %s %s",
+		line = String.format("Frames: %d Points: %s | Queued uploads: %d%s | %s %s %s",
 				rendered,
 				creditsEarned != null ? creditsEarned : "unknown",
-				(this.uploadQueueSize > 0 ? String.format("Upload queue: %d (%.2fMB) | ",
-						this.uploadQueueSize, (this.uploadQueueVolume / 1024.0 / 1024.0)) : ""),
+				this.uploadQueueSize,
+				(this.uploadQueueSize > 0 ? String.format(" (%.2fMB)", (this.uploadQueueVolume / 1024.0 / 1024.0)) : ""),
 				project,
 				computeMethod,
 				status + (exiting ? " (Exiting after all frames are uploaded)" : "")

--- a/src/com/sheepit/client/standalone/swing/activity/Working.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Working.java
@@ -71,13 +71,14 @@ public class Working implements Activity {
 	private JLabel waiting_projects_value;
 	private JLabel connected_machines_value;
 	private JLabel user_info_total_rendertime_this_session_value;
+	private JLabel userInfoQueuedUploadsAndSizeValue;
 	private String currentTheme;
 	
 	public Working(GuiSwing parent_) {
 		parent = parent_;
 		
 		statusContent = new JLabel("Init");
-		renderedFrameContent = new JLabel("");
+		renderedFrameContent = new JLabel("0");
 		remainingFrameContent = new JLabel("");
 		creditEarned = new JLabel("");
 		current_project_name_value = new JLabel("");
@@ -91,6 +92,7 @@ public class Working implements Activity {
 		user_info_total_rendertime_this_session_value = new JLabel("");
 		lastRenderTime = new JLabel("");
 		lastRender = new JLabel("");
+		userInfoQueuedUploadsAndSizeValue = new JLabel("0");
 		currentTheme = UIManager.getLookAndFeel().getName();    // Capture the theme on component instantiation
 	}
 	
@@ -118,6 +120,7 @@ public class Working implements Activity {
 			user_info_total_rendertime_this_session_value = new JLabel(user_info_total_rendertime_this_session_value.getText());
 			lastRenderTime = new JLabel(lastRenderTime.getText());
 			lastRender = new JLabel(lastRender.getText());
+			userInfoQueuedUploadsAndSizeValue = new JLabel(userInfoQueuedUploadsAndSizeValue.getText());
 
 			// set the new theme as the current one
 			currentTheme = UIManager.getLookAndFeel().getName();
@@ -154,6 +157,7 @@ public class Working implements Activity {
 		
 		JLabel user_info_credits_this_session = new JLabel("Points earned: ", JLabel.TRAILING);
 		JLabel user_info_total_rendertime_this_session = new JLabel("Duration: ", JLabel.TRAILING);
+		JLabel user_info_pending_uploads_and_size = new JLabel("Queued uploads: ", JLabel.TRAILING);
 		JLabel user_info_rendered_frame_this_session = new JLabel("Rendered frames: ", JLabel.TRAILING);
 		JLabel global_static_renderable_project = new JLabel("Renderable projects: ", JLabel.TRAILING);
 		
@@ -162,6 +166,9 @@ public class Working implements Activity {
 		
 		session_info_panel.add(user_info_rendered_frame_this_session);
 		session_info_panel.add(renderedFrameContent);
+		
+		session_info_panel.add(user_info_pending_uploads_and_size);
+		session_info_panel.add(userInfoQueuedUploadsAndSizeValue);
 		
 		session_info_panel.add(global_static_renderable_project);
 		session_info_panel.add(renderable_projects_value);
@@ -193,7 +200,7 @@ public class Working implements Activity {
 		// last frame
 		JPanel last_frame_panel = new JPanel();
 		last_frame_panel.setLayout(new BoxLayout(last_frame_panel, BoxLayout.Y_AXIS));
-		last_frame_panel.setBorder(BorderFactory.createTitledBorder("Last rendered frame"));
+		last_frame_panel.setBorder(BorderFactory.createTitledBorder("Last uploaded frame"));
 		lastRender.setIcon(new ImageIcon(new BufferedImage(200, 120, BufferedImage.TYPE_INT_ARGB)));
 		lastRender.setAlignmentX(Component.CENTER_ALIGNMENT);
 		lastRenderTime.setAlignmentX(Component.CENTER_ALIGNMENT);
@@ -245,10 +252,10 @@ public class Working implements Activity {
 		
 		Spring widthLeftColumn = getBestWidth(current_project_panel, 4, 2);
 		widthLeftColumn = Spring.max(widthLeftColumn, getBestWidth(global_stats_panel, 4, 2));
-		widthLeftColumn = Spring.max(widthLeftColumn, getBestWidth(session_info_panel, 3, 2));
+		widthLeftColumn = Spring.max(widthLeftColumn, getBestWidth(session_info_panel, 4, 2));
 		alignPanel(current_project_panel, 5, 2, widthLeftColumn);
 		alignPanel(global_stats_panel, 4, 2, widthLeftColumn);
-		alignPanel(session_info_panel, 4, 2, widthLeftColumn);
+		alignPanel(session_info_panel, 5, 2, widthLeftColumn);
 	}
 	
 	public void setStatus(String msg_) {
@@ -279,7 +286,16 @@ public class Working implements Activity {
 		renderable_projects_value.setText(df.format(stats.getRenderableProject()));
 		waiting_projects_value.setText(df.format(stats.getWaitingProject()));
 		connected_machines_value.setText(df.format(stats.getConnectedMachine()));
+		
 		updateTime();
+	}
+	
+	public void displayUploadQueueStats(int queueSize, long queueVolume) {
+		userInfoQueuedUploadsAndSizeValue.setText(String.format("%d (%.2fMB) %s",
+				queueSize,
+				(queueVolume / 1024.0 / 1024.0),
+				(queueSize == this.parent.getConfiguration().getMaxUploadingJob() ? "- Queue full!" : "")
+		));
 	}
 	
 	public void updateTime() {

--- a/src/com/sheepit/client/standalone/swing/activity/Working.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Working.java
@@ -291,9 +291,9 @@ public class Working implements Activity {
 	}
 	
 	public void displayUploadQueueStats(int queueSize, long queueVolume) {
-		userInfoQueuedUploadsAndSizeValue.setText(String.format("%d (%.2fMB) %s",
+		userInfoQueuedUploadsAndSizeValue.setText(String.format("%d%s%s",
 				queueSize,
-				(queueVolume / 1024.0 / 1024.0),
+				(queueSize > 0 ? String.format(" (%.2fMB) ", (queueVolume / 1024.0 / 1024.0)) : ""),
 				(queueSize == this.parent.getConfiguration().getMaxUploadingJob() ? "- Queue full!" : "")
 		));
 	}


### PR DESCRIPTION
With the new feature (#209) that unlocks the upload of frames in the background, is sometimes difficult to know the status of the client. Questions like how many uploads are waiting in the queue or what's the size of the upload queue are not evident for the user.

This PR contains the following improvements to the background upload process:
- New information added to all the clients (GUI, text and oneLine) to show the number of frames waiting to be uploaded and the total size of the upload.
- Different messages to inform if the frame is going to be sent synchronously or is queued.
- A new message indicating when the client is not taking new jobs while the upload queue is full. This is happening as soon as the upload queue reaches 3 files.

- GUI UI additional information example:
![gui - uploadingQueue](https://user-images.githubusercontent.com/4283528/79437736-f3224780-8015-11ea-840b-02db954dd9da.png)
![gui - uploadingQueue 2](https://user-images.githubusercontent.com/4283528/79437742-f4ec0b00-8015-11ea-8031-1f5690010e3f.png)

- Text UI information example:
![text - uploadingQueue 2](https://user-images.githubusercontent.com/4283528/79437838-1220d980-8016-11ea-84d7-84f01734b592.png)

- oneLine UI additional information example:
![oneLine - uploadQueue](https://user-images.githubusercontent.com/4283528/79437932-354b8900-8016-11ea-977e-e01a8415109a.png)
