### PR TITLE
feature: block current frame/current project permanently for current client instance

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -37,6 +37,7 @@ import com.sheepit.client.Error.ServerCode;
 import com.sheepit.client.Error.Type;
 import com.sheepit.client.exception.FermeException;
 import com.sheepit.client.exception.FermeExceptionBadResponseFromServer;
+import com.sheepit.client.exception.FermeExceptionJobBlockedByUser;
 import com.sheepit.client.exception.FermeExceptionNoRendererAvailable;
 import com.sheepit.client.exception.FermeExceptionNoRightToRender;
 import com.sheepit.client.exception.FermeExceptionNoSession;
@@ -160,6 +161,16 @@ public class Client {
 					}
 					this.gui.status("Requesting Job");
 					this.renderingJob = this.server.requestJob();
+				}
+				catch (FermeExceptionJobBlockedByUser e) {
+					Job frame_to_reset = this.renderingJob;
+					this.renderingJob = null;
+					this.gui.error("Job previously blocked");
+					this.sendError(step, frame_to_reset, Type.RENDERER_KILLED_BY_USER);
+					this.log.removeCheckPoint(step);
+					
+					this.log.info("Client::run Server assigned a job previously blocked by user");
+					continue;
 				}
 				catch (FermeExceptionNoRightToRender e) {
 					this.gui.error("User does not have enough right to render scene");

--- a/src/com/sheepit/client/Configuration.java
+++ b/src/com/sheepit/client/Configuration.java
@@ -210,6 +210,13 @@ public class Configuration {
 							
 							// TODO: remove old one
 						}
+						else if (extension.equals(".blocked")) {
+							// The following situation (a .block semaphore without the associated job zip file) should
+							// NEVER occur, but we check anyhow to avoid having orphan semaphores
+							if (!new File(dir + File.separator + name + ".zip").exists()) {
+								file.delete();
+							}
+						}
 						else {
 							file.delete();
 						}

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -579,12 +579,6 @@ public class Job {
 		}
 	}
 
-	public boolean isBlockedByUser() {
-		String blockSemaphore = configuration.getWorkingDirectory().getAbsolutePath() + File.separator + this.getSceneMD5() + ".blocked";
-		
-		return new File(blockSemaphore).exists();
-	}
-	
 	private Type detectError(String line) {
 		
 		if (line.contains("CUDA error: Out of memory")) {

--- a/src/com/sheepit/client/exception/FermeExceptionJobBlockedByUser.java
+++ b/src/com/sheepit/client/exception/FermeExceptionJobBlockedByUser.java
@@ -1,0 +1,14 @@
+package com.sheepit.client.exception;
+
+/****
+ * This exception will be raised when the server returns a job that has been previously blocked by the user
+ */
+public class FermeExceptionJobBlockedByUser extends FermeException {
+	public FermeExceptionJobBlockedByUser() {
+		super();
+	}
+	
+	public FermeExceptionJobBlockedByUser(String message_) {
+		super(message_);
+	}
+}

--- a/src/com/sheepit/client/standalone/swing/activity/Working.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Working.java
@@ -39,6 +39,7 @@ import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.UIManager;
 import javax.swing.Spring;
@@ -218,7 +219,7 @@ public class Working implements Activity {
 		
 		pauseButton.addActionListener(new PauseAction());
 		
-		JButton blockJob = new JButton("Block this project");
+		JButton blockJob = new JButton("Block this frame/project");
 		blockJob.addActionListener(new blockJobAction());
 		
 		exitAfterFrame = new JButton("Exit after this frame");
@@ -452,13 +453,35 @@ public class Working implements Activity {
 	class blockJobAction implements ActionListener {
 		@Override
 		public void actionPerformed(ActionEvent e) {
-			Client client = parent.getClient();
-			if (client != null) {
-				Job job = client.getRenderingJob();
-				if (job != null) {
-					job.block();
+			String[] blockJobOptions = {"This Frame Only", "Whole Project", "Do Nothing"};
+			
+			int userDecision = JOptionPane.showOptionDialog(
+					null,
+					"Do you want to block this frame only or the whole project?\n\nNOTE: The decision applies to this client instance only. Other instances can potentially receive this frame or job again.",
+					"Block frame or project",
+					JOptionPane.DEFAULT_OPTION,
+					JOptionPane.QUESTION_MESSAGE,
+					null,
+					blockJobOptions,
+					blockJobOptions[2]);    // Make the "Do nothing" button the default one to avoid mistakes
+			
+			if(userDecision < 2) {  // If user selects one "This frame only" or "Whole Project"
+				Client client = parent.getClient();
+				
+				if (client != null) {
+					Job job = client.getRenderingJob();
+					if (job != null) {
+						if (userDecision == 0) {   // Block this frame only
+							job.block(Job.FRAME_BLOCK);
+						} else {                    // Block the project permanently for this instance
+							job.block(Job.PERMANENT_PROJECT_BLOCK);
+						}
+					}
 				}
+			} else {
+				System.out.println("No Option");
 			}
+			
 		}
 	}
 	

--- a/src/com/sheepit/client/standalone/text/CLIInputActionHandler.java
+++ b/src/com/sheepit/client/standalone/text/CLIInputActionHandler.java
@@ -39,7 +39,13 @@ public class CLIInputActionHandler implements CLIInputListener {
 		if (command.equalsIgnoreCase("block")) {
 			Job job = client.getRenderingJob();
 			if (job != null) {
-				job.block();
+				job.block(Job.FRAME_BLOCK);
+			}
+		}
+		else if (command.equalsIgnoreCase("permblock")) {
+			Job job = client.getRenderingJob();
+			if (job != null) {
+				job.block(Job.PERMANENT_PROJECT_BLOCK);
 			}
 		}
 		else if (command.equalsIgnoreCase("resume")) {
@@ -66,14 +72,15 @@ public class CLIInputActionHandler implements CLIInputListener {
 		}
 		else {
 			System.out.println("Unknown command: " + command);
-			System.out.println("status: display client status");
+			System.out.println("status:    display client status");
 			System.out.println("priority <n>: set the priority for the next renderjob");
-			System.out.println("block:  block project");
-			System.out.println("pause:  pause client requesting new jobs");
-			System.out.println("resume: resume after client was paused");
-			System.out.println("stop:   exit after frame was finished");
-			System.out.println("cancel: cancel exit");
-			System.out.println("quit:   exit now");
+			System.out.println("block:     block current frame");
+			System.out.println("permblock: permanently block current project NOTE: only affects this client instance");
+			System.out.println("pause:     pause client requesting new jobs");
+			System.out.println("resume:    resume after client was paused");
+			System.out.println("stop:      exit after frame was finished");
+			System.out.println("cancel:    cancel exit");
+			System.out.println("quit:      exit now");
 		}
 	}
 	


### PR DESCRIPTION
With the current client/server implementation the possibility of receiving a frame from a previously blocked project exists. This new feature allows the client to:
 - Block the current frame (same functionality that exists today) or;
 - Block the current project permanently (new frames from the project assigned by the server will be automatically blocked/rejected by the client).

A new option dialog has been added to the _Block this frame/project_ button to allow the user to select the proper action. A new _permblock_ command has also been added to the CLI based GUIs to block the project permanently.

Please note that the blocking functionality only applies to the current client instance (other copies of the client running in the same/different computer may potentially receive frames from the blocked project again). This behaviour is by design as every client might have different rendering capacities (memory or cores assigned, CPU/GPU, etc.) so the user can decide the behaviour per client.

IMPORTANT: the list of blocked projects will be deleted between client executions unless the _-cache-dir_ option is used to invoke the client.

Screenshot:
![new-block-frame-project-dialog](https://user-images.githubusercontent.com/4283528/79557698-55e31400-80e6-11ea-80b0-e02971d9bca6.png)