### PR TITLE
Improve the pause button screen workflow

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -138,6 +138,9 @@ public class Client {
 			while (this.running == true) {
 				this.renderingJob = null;
 				synchronized (this) {
+					if (this.suspended) {
+						this.gui.status("Client paused", true);
+					}
 					while (this.suspended) {
 						wait();
 					}
@@ -431,6 +434,7 @@ public class Client {
 	
 	public void suspend() {
 		suspended = true;
+		this.gui.status("Client will pause when the current job finishes", true);
 	}
 	
 	public synchronized void resume() {

--- a/src/com/sheepit/client/Gui.java
+++ b/src/com/sheepit/client/Gui.java
@@ -25,6 +25,8 @@ public interface Gui {
 	public void stop();
 	
 	public void status(String msg_);
+	
+	public void status(String msg_, boolean overwriteSuspendedMsg);
 
 	public void updateTrayIcon(Integer percentage_);
 

--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -187,11 +187,16 @@ public class GuiSwing extends JFrame implements Gui {
 	
 	@Override
 	public void status(String msg_) {
-		if (activityWorking != null) {
-			this.activityWorking.setStatus(msg_);
-		}
+		status(msg_, false);
 	}
 	
+	@Override
+	public void status(String msg_, boolean overwriteSuspendedMsg) {
+		if (activityWorking != null) {
+			this.activityWorking.setStatus(msg_, overwriteSuspendedMsg);
+		}
+	}
+
 	@Override
 	public void setRenderingProjectName(String name_) {
 		if (activityWorking != null) {

--- a/src/com/sheepit/client/standalone/GuiText.java
+++ b/src/com/sheepit/client/standalone/GuiText.java
@@ -95,8 +95,21 @@ public class GuiText implements Gui {
 
 	@Override
 	public void status(String msg_) {
-		System.out.println(msg_);
+		status(msg_, false);
+	}
+	
+	@Override
+	public void status(String msg_, boolean overwriteSuspendedMsg) {
 		log.debug("GUI " + msg_);
+		
+		if (client != null && client.isSuspended()) {
+			if (overwriteSuspendedMsg) {
+				System.out.println(msg_);
+			}
+		}
+		else {
+			System.out.println(msg_);
+		}
 	}
 	
 	@Override

--- a/src/com/sheepit/client/standalone/GuiTextOneLine.java
+++ b/src/com/sheepit/client/standalone/GuiTextOneLine.java
@@ -106,8 +106,21 @@ public class GuiTextOneLine implements Gui {
 
 	@Override
 	public void status(String msg_) {
-		status = msg_;
-		updateLine();
+		status(msg_, false);
+	}
+	
+	@Override
+	public void status(String msg_, boolean overwriteSuspendedMsg) {
+		if (client != null && client.isSuspended()) {
+			if (overwriteSuspendedMsg) {
+				status = msg_;
+				updateLine();
+			}
+		}
+		else {
+			status = msg_;
+			updateLine();
+		}
 	}
 	
 	@Override

--- a/src/com/sheepit/client/standalone/swing/activity/Working.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Working.java
@@ -55,6 +55,7 @@ public class Working implements Activity {
 	private GuiSwing parent;
 	
 	private JLabel statusContent;
+	private String previousStatus;
 	private JLabel renderedFrameContent;
 	private JLabel remainingFrameContent;
 	private JLabel lastRenderTime;
@@ -94,6 +95,7 @@ public class Working implements Activity {
 		lastRender = new JLabel("");
 		userInfoQueuedUploadsAndSizeValue = new JLabel("0");
 		currentTheme = UIManager.getLookAndFeel().getName();    // Capture the theme on component instantiation
+		previousStatus = "";
 	}
 	
 	@Override
@@ -217,10 +219,10 @@ public class Working implements Activity {
 		JButton settingsButton = new JButton("Settings");
 		settingsButton.addActionListener(new SettingsAction());
 		
-		pauseButton = new JButton("Pause");
+		pauseButton = new JButton("Pause getting new jobs");
 		Client client = parent.getClient();
 		if (client != null && client.isSuspended()) {
-			pauseButton.setText("Resume");
+			pauseButton.setText("Resume getting jobs");
 		}
 		
 		pauseButton.addActionListener(new PauseAction());
@@ -259,7 +261,24 @@ public class Working implements Activity {
 	}
 	
 	public void setStatus(String msg_) {
-		statusContent.setText("<html>" + msg_ + "</html>");
+		setStatus(msg_, false);
+	}
+	
+	public void setStatus(String msg_, boolean overwriteSuspendedMsg) {
+		Client client = parent.getClient();
+		
+		if (!msg_.equals("")) {
+			this.previousStatus = msg_;
+		}
+		
+		if (client != null && client.isSuspended()) {
+			if (overwriteSuspendedMsg) {
+				statusContent.setText("<html>" + msg_ + "</html>");
+			}
+		}
+		else {
+			statusContent.setText("<html>" + msg_ + "</html>");
+		}
 	}
 	
 	public void setRenderingProjectName(String msg_) {
@@ -343,7 +362,7 @@ public class Working implements Activity {
 						if (width * factor > 200) {
 							factor = Math.min(factor, 200f / width);
 						}
-						icon = new ImageIcon(img.getScaledInstance((int)(width * factor), (int)(height * factor), Image.SCALE_FAST));
+						icon = new ImageIcon(img.getScaledInstance((int) (width * factor), (int) (height * factor), Image.SCALE_FAST));
 					}
 					catch (IOException e) {
 						System.out.println("Working::showLastRender() exception " + e);
@@ -428,12 +447,14 @@ public class Working implements Activity {
 			Client client = parent.getClient();
 			if (client != null) {
 				if (client.isSuspended()) {
-					pauseButton.setText("Pause");
+					pauseButton.setText("Pause getting new jobs");
 					client.resume();
+					setStatus(previousStatus);
 				}
 				else {
-					pauseButton.setText("Resume");
+					pauseButton.setText("Resume getting jobs");
 					client.suspend();
+					setStatus("");
 				}
 			}
 		}


### PR DESCRIPTION
This PR improves the overall process of manually pausing the client. Main changes in the client:
- Changed the labels of the _pause_ button to make the action more explicit
- Changed the status label:
   - While the client is still finishing the current job
   - Once the client is paused and stops retrieving new jobs

The three (GUI, text and OneLine) UIs have been adapted to the new capabilities.
