### PR TITLE
Feature: increase tile size when using a GPU

### DIFF
--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -168,7 +168,7 @@ public class Job {
 			+ "signal.signal(signal.SIGINT, hndl)\n";
 		if (isUseGPU() && configuration.getGPUDevice() != null && configuration.getComputeMethod() != ComputeType.CPU) {
 			// If using a GPU, check the proper tile size
-			int tileSize = configuration.getGPUDevice().getRecommandedTileSize();
+			int tileSize = configuration.getGPUDevice().getRenderbucketSize();
 
 			core_script = "sheepit_set_compute_device(\"" + configuration.getGPUDevice().getType() + "\", \"GPU\", \"" + configuration.getGPUDevice().getId() + "\")\n";
 			core_script += String.format("bpy.context.scene.render.tile_x = %1$d\nbpy.context.scene.render.tile_y = %1$d\n",

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -167,16 +167,24 @@ public class Job {
 			+ "    pass\n"
 			+ "signal.signal(signal.SIGINT, hndl)\n";
 		if (isUseGPU() && configuration.getGPUDevice() != null && configuration.getComputeMethod() != ComputeType.CPU) {
+			// If using a GPU, check the proper tile size
+			int tileSize = configuration.getGPUDevice().getRecommandedTileSize();
+
 			core_script = "sheepit_set_compute_device(\"" + configuration.getGPUDevice().getType() + "\", \"GPU\", \"" + configuration.getGPUDevice().getId() + "\")\n";
+			core_script += String.format("bpy.context.scene.render.tile_x = %1$d\nbpy.context.scene.render.tile_y = %1$d\n",
+					tileSize);
+			
+			log.debug(String.format("Rendering tile size increased to %1$dx%1$d pixels", tileSize));
 			gui.setComputeMethod("GPU");
 		}
 		else {
+			// Otherwise (CPU), fix the tile size to 32x32px
 			core_script = "sheepit_set_compute_device(\"NONE\", \"CPU\", \"CPU\")\n";
+			core_script += String.format("bpy.context.scene.render.tile_x = %1$d\nbpy.context.scene.render.tile_y = %1$d\n", 32);
 			gui.setComputeMethod("CPU");
 		}
 		
 		core_script += ignore_signal_script;
-		core_script += String.format("bpy.context.scene.render.tile_x = %1$d\nbpy.context.scene.render.tile_y = %1$d\n", 32);
 		File script_file = null;
 		String command1[] = getRendererCommand().split(" ");
 		int size_command = command1.length + 2; // + 2 for script

--- a/src/com/sheepit/client/hardware/gpu/GPUDevice.java
+++ b/src/com/sheepit/client/hardware/gpu/GPUDevice.java
@@ -23,6 +23,7 @@ public class GPUDevice {
 	private String type;
 	private String model;
 	private long memory; // in B
+	private int renderbucketSize;
 	
 	private String id;
 	
@@ -33,6 +34,7 @@ public class GPUDevice {
 		this.model = model;
 		this.memory = ram;
 		this.id = id;
+		this.renderbucketSize = getRecommandedTileSize(type);
 	}
 	
 	public GPUDevice(String type, String model, long ram, String id, String oldId) {
@@ -80,10 +82,48 @@ public class GPUDevice {
 		this.oldId = id;
 	}
 	
-	public int getRecommandedTileSize() {
-		// check the optimal tile size for the GPU. As a tactical solution, we start with 256x256px tile size for
-		// GPUs with more than 1GB of VRAM, 128x128x otherwise
-		return (getMemory() > 1073741824L) ? 256 : 128;
+	public int getRenderbucketSize() {
+		return this.renderbucketSize;
+	}
+	
+	public void setRenderbucketSize(int proposedRenderbucketSize) {
+		int renderbucketSize = getRecommandedTileSize(this.type);    // minimum recommended renderbucket size for GPUs
+		
+		if (proposedRenderbucketSize > 32) {
+			if (getType().equals("CUDA")) {
+				if (proposedRenderbucketSize <= 512) {
+					renderbucketSize = proposedRenderbucketSize;
+				}
+				else {
+					renderbucketSize = getRecommandedTileSize("CUDA");
+				}
+			}
+			else if (getType().equals("OPENGL")) {
+				if (proposedRenderbucketSize <= 2048) {
+					renderbucketSize = proposedRenderbucketSize;
+				}
+				else {
+					renderbucketSize = getRecommandedTileSize("OPENCL");
+				}
+			}
+		}
+		
+		this.renderbucketSize = renderbucketSize;
+	}
+	
+	private int getRecommandedTileSize(String type) {
+		if (getType().equals("CUDA")) {
+			// Optimal CUDA-based GPUs Renderbucket algorithm
+			return (getMemory() > 1073741824L) ? 256 : 128;
+		}
+		else if (getType().equals("OPENGL")) {
+			// Optimal OpenCL-based GPUs Renderbucket algorithm
+			return (getMemory() > 1073741824L) ? 256 : 128;
+		}
+		else {
+			// This branch should not be reached, but if it does, then set the size to 32x32 pixels (safest option)
+			return 32;
+		}
 	}
 	
 	@Override

--- a/src/com/sheepit/client/hardware/gpu/GPUDevice.java
+++ b/src/com/sheepit/client/hardware/gpu/GPUDevice.java
@@ -80,6 +80,12 @@ public class GPUDevice {
 		this.oldId = id;
 	}
 	
+	public int getRecommandedTileSize() {
+		// check the optimal tile size for the GPU. As a tactical solution, we start with 256x256px tile size for
+		// GPUs with more than 1GB of VRAM, 128x128x otherwise
+		return (getMemory() > 1073741824L) ? 256 : 128;
+	}
+	
 	@Override
 	public String toString() {
 		return "GPUDevice [type=" + type + ", model='" + model + "', memory=" + memory + ", id=" + id + "]";

--- a/src/com/sheepit/client/hardware/gpu/GPUDevice.java
+++ b/src/com/sheepit/client/hardware/gpu/GPUDevice.java
@@ -89,7 +89,7 @@ public class GPUDevice {
 	public void setRenderbucketSize(int proposedRenderbucketSize) {
 		int renderbucketSize = getRecommandedTileSize(this.type);    // minimum recommended renderbucket size for GPUs
 		
-		if (proposedRenderbucketSize > 32) {
+		if (proposedRenderbucketSize >= 32) {
 			if (getType().equals("CUDA")) {
 				if (proposedRenderbucketSize <= 512) {
 					renderbucketSize = proposedRenderbucketSize;

--- a/src/com/sheepit/client/standalone/Worker.java
+++ b/src/com/sheepit/client/standalone/Worker.java
@@ -111,6 +111,9 @@ public class Worker {
 	
 	@Option(name = "-theme", usage = "Specify the theme to use for the graphical client, default 'light', available 'light', 'dark'", required = false)
 	private String theme = null;
+	
+	@Option(name = "-renderbucket-size", usage = "Set a custom GPU renderbucket size (32 for 32x32px, 64 for 64x64px, and so on). NVIDIA GPUs support a maximum renderbucket size of 512x512 pixel, while AMD GPUs support a maximum 2048x2048 pixel renderbucket size. Minimum renderbucket size is 32 pixels for all GPUs", required = false)
+	private int renderbucketSize = 0;
 
 	public static void main(String[] args) {
 		new Worker().doMain(args);
@@ -303,6 +306,26 @@ public class Worker {
 		}
 		
 		Log.getInstance(config).debug("client version " + config.getJarVersion());
+		
+		
+		if (renderbucketSize > 0) {
+			if (config.getComputeMethod() == ComputeType.CPU_GPU || config.getComputeMethod() == ComputeType.GPU) {
+				// Send the proposed renderbucket size and check if viable
+				config.getGPUDevice().setRenderbucketSize(renderbucketSize);
+				
+				if (config.getGPUDevice().getRenderbucketSize() == renderbucketSize) {
+					Log.getInstance(config).debug(String.format("User set a renderbucket size of %1$dx%1$dpx for the GPU %2$s",
+							renderbucketSize,
+							config.getGPUDevice().getModel()));
+				}
+				else {
+					Log.getInstance(config).debug(String.format("User set an invalid renderbucket size (%1$dx%1$dpx) for the GPU %2$s. Reverting to %3$dx%3$dpx",
+							renderbucketSize,
+							config.getGPUDevice().getModel(),
+							config.getGPUDevice().getRenderbucketSize()));
+				}
+			}
+		}
 		
 		Gui gui;
 		String type = config.getUIType();


### PR DESCRIPTION
Increased tile size when using GPU rendering to increase performance. This release contains two fixed tile sizes for GPUs:
GPU with <1Gb VRAM: 128x128px
All other GPUs: 256x256px

CPUs have a fixed tile size of 32x32px.