### PR TITLE
Fix JAXB NoClassDefFoundError on Java 9+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	compile 'net.lingala.zip4j:zip4j:1.3.3'
 	compile 'net.java.dev.jna:jna-platform:5.0.0'
 	compile 'org.simpleframework:simple-xml:2.7.1'
+	compile 'javax.xml.bind:jaxb-api:2.3.1'
 	implementation 'com.formdev:flatlaf:0.30'
 }
 

--- a/src/com/sheepit/client/Server.java
+++ b/src/com/sheepit/client/Server.java
@@ -340,7 +340,7 @@ public class Server extends Thread implements HostnameVerifier, X509TrustManager
 				
 				script += jobData.getRenderTask().getScript();
 
-				String validationUrl = URLDecoder.decode(jobData.getRenderTask().getValidationUrl());
+				String validationUrl = URLDecoder.decode(jobData.getRenderTask().getValidationUrl(), "UTF-8");
 
 				Job a_job = new Job(
 						this.user_config,


### PR DESCRIPTION
```
java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter
        at com.sheepit.client.Utils.md5(Utils.java:83)
        at com.sheepit.client.Configuration.cleanDirectory(Configuration.java:205)
        at com.sheepit.client.Configuration.cleanWorkingDirectory(Configuration.java:185)
        at com.sheepit.client.Client.run(Client.java:113)
        at com.sheepit.client.standalone.GuiSwing$ThreadClient.run(GuiSwing.java:425)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:602)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        ... 5 more
```
JAXB APIs are considered to be a part of Java EE and was removed by default in Java SE 9.
See: https://stackoverflow.com/a/47412779/6238618

Additionally this commit also fixed a deprecation warning.