### PR TITLE
Allow the user to configure the GPU render bucket size 

### DIFF
--- a/src/com/sheepit/client/Configuration.java
+++ b/src/com/sheepit/client/Configuration.java
@@ -57,6 +57,7 @@ public class Configuration {
 	private int priority;
 	private ComputeType computeMethod;
 	private GPUDevice GPUDevice;
+	private int renderbucketSize;
 	private boolean detectGPUs;
 	private boolean printLog;
 	private List<Pair<Calendar, Calendar>> requestTime;
@@ -80,6 +81,7 @@ public class Configuration {
 		this.priority = 19; // default lowest
 		this.computeMethod = null;
 		this.GPUDevice = null;
+		this.renderbucketSize = -1;
 		this.userHasSpecifiedACacheDir = false;
 		this.detectGPUs = true;
 		this.workingDirectory = null;

--- a/src/com/sheepit/client/Configuration.java
+++ b/src/com/sheepit/client/Configuration.java
@@ -95,17 +95,16 @@ public class Configuration {
 		this.theme = null;
 	}
 	
+	
 	public String toString() {
 		return String.format("Configuration (workingDirectory '%s')", this.workingDirectory.getAbsolutePath());
 	}
 
 	public void setUsePriority(int priority) {
-		if (priority > 19) {
+		if (priority > 19)
 			priority = 19;
-		}
-		if (priority < -19) {
+		if (priority < -19)
 			priority = -19;
-		}
 		
 		this.priority = priority;
 		

--- a/src/com/sheepit/client/Configuration.java
+++ b/src/com/sheepit/client/Configuration.java
@@ -95,16 +95,17 @@ public class Configuration {
 		this.theme = null;
 	}
 	
-	
 	public String toString() {
 		return String.format("Configuration (workingDirectory '%s')", this.workingDirectory.getAbsolutePath());
 	}
 
 	public void setUsePriority(int priority) {
-		if (priority > 19)
+		if (priority > 19) {
 			priority = 19;
-		if (priority < -19)
+		}
+		if (priority < -19) {
 			priority = -19;
+		}
 		
 		this.priority = priority;
 		

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -162,10 +162,10 @@ public class Job {
 		// When sending Ctrl+C to the terminal it also get's sent to all subprocesses e.g. also the render process.
 		// The java program handles Ctrl+C but the renderer quits on Ctrl+C.
 		// This script causes the renderer to ignore Ctrl+C.
-		String ignore_signal_script = "import signal\n"
-				+ "def hndl(signum, frame):\n"
-				+ "    pass\n"
-				+ "signal.signal(signal.SIGINT, hndl)\n";
+		String ignore_signal_script= "import signal\n"
+			+ "def hndl(signum, frame):\n"
+			+ "    pass\n"
+			+ "signal.signal(signal.SIGINT, hndl)\n";
 		if (isUseGPU() && configuration.getGPUDevice() != null && configuration.getComputeMethod() != ComputeType.CPU) {
 			// If using a GPU, check the proper tile size
 			int tileSize = configuration.getGPUDevice().getRenderbucketSize();
@@ -274,8 +274,8 @@ public class Job {
 					public void run() {
 						RenderProcess process = getProcessRender();
 						if (process != null) {
-							long duration = (new Date().getTime() - process.getStartTime()) / 1000; // in seconds
-							if (configuration.getMaxRenderTime() > 0 && duration > configuration.getMaxRenderTime()) {
+							long duration = (new Date().getTime() - process.getStartTime() ) / 1000; // in seconds
+							if (configuration.getMaxRenderTime() > 0 &&  duration > configuration.getMaxRenderTime()) {
 								log.debug("Killing render because process duration");
 								OS.getOS().kill(process.getProcess());
 								setAskForRendererKill(true);
@@ -378,7 +378,7 @@ public class Job {
 		if (isAskForRendererKill()) {
 			log.debug("Job::render been asked to end render");
 			
-			long duration = (new Date().getTime() - process.getStartTime()) / 1000; // in seconds
+			long duration = (new Date().getTime() - process.getStartTime() ) / 1000; // in seconds
 			if (configuration.getMaxRenderTime() > 0 && duration > configuration.getMaxRenderTime()) {
 				log.debug("Render killed because process duration (" + duration + "s) is over user setting (" + configuration.getMaxRenderTime() + "s)");
 				return Error.Type.RENDERER_KILLED_BY_USER_OVER_TIME;
@@ -423,7 +423,7 @@ public class Job {
 		else {
 			setOutputImagePath(files[0].getAbsolutePath());
 			this.outputImageSize = new File(getOutputImagePath()).length();
-			log.debug(String.format("Job::render pictureFilename: %s, size: %d'", getOutputImagePath(), this.outputImageSize));
+			log.debug(String.format("Job::render pictureFilename: %s, size: %d'",getOutputImagePath(), this.outputImageSize));
 		}
 		
 		File scene_dir = new File(getSceneDirectory());
@@ -443,7 +443,7 @@ public class Job {
 
 		if (standardTileInfo.find()) {
 			int tileJustProcessed = Integer.parseInt(standardTileInfo.group(1));
-			int totalTilesInJob = Integer.parseInt(standardTileInfo.group(2));
+			int totalTilesInJob  = Integer.parseInt(standardTileInfo.group(2));
 
 			newProgress = Math.abs((tileJustProcessed * 100) / totalTilesInJob);
 		}

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -162,10 +162,10 @@ public class Job {
 		// When sending Ctrl+C to the terminal it also get's sent to all subprocesses e.g. also the render process.
 		// The java program handles Ctrl+C but the renderer quits on Ctrl+C.
 		// This script causes the renderer to ignore Ctrl+C.
-		String ignore_signal_script= "import signal\n"
-			+ "def hndl(signum, frame):\n"
-			+ "    pass\n"
-			+ "signal.signal(signal.SIGINT, hndl)\n";
+		String ignore_signal_script = "import signal\n"
+				+ "def hndl(signum, frame):\n"
+				+ "    pass\n"
+				+ "signal.signal(signal.SIGINT, hndl)\n";
 		if (isUseGPU() && configuration.getGPUDevice() != null && configuration.getComputeMethod() != ComputeType.CPU) {
 			// If using a GPU, check the proper tile size
 			int tileSize = configuration.getGPUDevice().getRenderbucketSize();
@@ -274,8 +274,8 @@ public class Job {
 					public void run() {
 						RenderProcess process = getProcessRender();
 						if (process != null) {
-							long duration = (new Date().getTime() - process.getStartTime() ) / 1000; // in seconds
-							if (configuration.getMaxRenderTime() > 0 &&  duration > configuration.getMaxRenderTime()) {
+							long duration = (new Date().getTime() - process.getStartTime()) / 1000; // in seconds
+							if (configuration.getMaxRenderTime() > 0 && duration > configuration.getMaxRenderTime()) {
 								log.debug("Killing render because process duration");
 								OS.getOS().kill(process.getProcess());
 								setAskForRendererKill(true);
@@ -378,7 +378,7 @@ public class Job {
 		if (isAskForRendererKill()) {
 			log.debug("Job::render been asked to end render");
 			
-			long duration = (new Date().getTime() - process.getStartTime() ) / 1000; // in seconds
+			long duration = (new Date().getTime() - process.getStartTime()) / 1000; // in seconds
 			if (configuration.getMaxRenderTime() > 0 && duration > configuration.getMaxRenderTime()) {
 				log.debug("Render killed because process duration (" + duration + "s) is over user setting (" + configuration.getMaxRenderTime() + "s)");
 				return Error.Type.RENDERER_KILLED_BY_USER_OVER_TIME;
@@ -423,7 +423,7 @@ public class Job {
 		else {
 			setOutputImagePath(files[0].getAbsolutePath());
 			this.outputImageSize = new File(getOutputImagePath()).length();
-			log.debug(String.format("Job::render pictureFilename: %s, size: %d'",getOutputImagePath(), this.outputImageSize));
+			log.debug(String.format("Job::render pictureFilename: %s, size: %d'", getOutputImagePath(), this.outputImageSize));
 		}
 		
 		File scene_dir = new File(getSceneDirectory());
@@ -443,7 +443,7 @@ public class Job {
 
 		if (standardTileInfo.find()) {
 			int tileJustProcessed = Integer.parseInt(standardTileInfo.group(1));
-			int totalTilesInJob  = Integer.parseInt(standardTileInfo.group(2));
+			int totalTilesInJob = Integer.parseInt(standardTileInfo.group(2));
 
 			newProgress = Math.abs((tileJustProcessed * 100) / totalTilesInJob);
 		}

--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -406,8 +406,7 @@ public class SettingsLoader {
 		if (config.getTheme() == null) {
 			if (this.theme != null) {
 				config.setTheme(this.theme);
-			}
-			else {
+			} else {
 				config.setTheme("light");
 			}
 		}

--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -406,7 +406,8 @@ public class SettingsLoader {
 		if (config.getTheme() == null) {
 			if (this.theme != null) {
 				config.setTheme(this.theme);
-			} else {
+			}
+			else {
 				config.setTheme("light");
 			}
 		}

--- a/src/com/sheepit/client/hardware/gpu/GPULister.java
+++ b/src/com/sheepit/client/hardware/gpu/GPULister.java
@@ -4,4 +4,8 @@ import java.util.List;
 
 public interface GPULister {
 	public abstract List<GPUDevice> getGpus();
+	
+	public abstract int getRecommendedRenderBucketSize(long memory);
+	
+	public abstract int getMaximumRenderBucketSize(long memory);
 }

--- a/src/com/sheepit/client/hardware/gpu/nvidia/Nvidia.java
+++ b/src/com/sheepit/client/hardware/gpu/nvidia/Nvidia.java
@@ -127,4 +127,14 @@ public class Nvidia implements GPULister {
 		return devices;
 	}
 	
+	@Override
+	public int getRecommendedRenderBucketSize(long memory) {
+		// Optimal CUDA-based GPUs Renderbucket algorithm
+		return (memory > 1073741824L) ? 256 : 128;
+	}
+	
+	@Override
+	public int getMaximumRenderBucketSize(long memory) {
+		return (memory > 1073741824L) ? 512 : 128;
+	}
 }

--- a/src/com/sheepit/client/hardware/gpu/opencl/OpenCL.java
+++ b/src/com/sheepit/client/hardware/gpu/opencl/OpenCL.java
@@ -123,6 +123,17 @@ public class OpenCL implements GPULister {
 		return available_devices;
 	}
 	
+	@Override
+	public int getRecommendedRenderBucketSize(long memory) {
+		// Optimal CUDA-based GPUs Renderbucket algorithm
+		return (memory > 1073741824L) ? 256 : 128;
+	}
+	
+	@Override
+	public int getMaximumRenderBucketSize(long memory) {
+		return (memory > 1073741824L) ? 2048 : 128;
+	}
+	
 	private static String getInfodeviceString(OpenCLLib lib, CLDeviceId.ByReference device, int type) {
 		byte name[] = new byte[256];
 		

--- a/src/com/sheepit/client/standalone/Worker.java
+++ b/src/com/sheepit/client/standalone/Worker.java
@@ -111,6 +111,9 @@ public class Worker {
 	
 	@Option(name = "-theme", usage = "Specify the theme to use for the graphical client, default 'light', available 'light', 'dark'", required = false)
 	private String theme = null;
+	
+	@Option(name = "-renderbucket-size", usage = "Set a custom GPU renderbucket size (32 for 32x32px, 64 for 64x64px, and so on). NVIDIA GPUs support a maximum renderbucket size of 512x512 pixel, while AMD GPUs support a maximum 2048x2048 pixel renderbucket size. Minimum renderbucket size is 32 pixels for all GPUs", required = false)
+	private int renderbucketSize = -1;
 
 	public static void main(String[] args) {
 		new Worker().doMain(args);
@@ -277,6 +280,12 @@ public class Worker {
 		}
 		
 		config.setComputeMethod(compute_method);
+		
+		// Change the default configuration if the user has specified a minimum renderbucket size of 32
+		if (renderbucketSize >= 32) {
+			// Send the proposed renderbucket size and check if viable
+			config.setRenderbucketSize(renderbucketSize);
+		}
 		
 		if (ui_type != null) {
 			config.setUIType(ui_type);

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -113,7 +113,7 @@ public class Settings implements Activity {
 		Configuration config = parent.getConfiguration();
 		new SettingsLoader(config.getConfigFilePath()).merge(config);
 		
-		applyTheme(config.getTheme());    // apply the proper theme (light/dark)
+		applyTheme(config.getTheme());	// apply the proper theme (light/dark)
 
 		List<GPUDevice> gpus = GPU.listDevices(config);
 		useGPUs.clear();    // Empty the auxiliary list (used in the list of checkboxes)
@@ -132,7 +132,7 @@ public class Settings implements Activity {
 		++currentRow;
 		
 		constraints.gridy = currentRow;
-		parent.getContentPane().add(new JLabel(" "), constraints);    // Add a separator between logo and first panel
+		parent.getContentPane().add(new JLabel(" "), constraints);	// Add a separator between logo and first panel
 
 		currentRow++;
 
@@ -331,14 +331,14 @@ public class Settings implements Activity {
 		CPU cpu = new CPU();
 		if (cpu.cores() > 1) { // if only one core is available, no need to show the choice
 			double step = 1;
-			double display = (double) cpu.cores() / step;
+			double display = (double)cpu.cores() / step;
 			while (display > 10) {
 				step += 1.0;
-				display = (double) cpu.cores() / step;
+				display = (double)cpu.cores() / step;
 			}
 			
 			cpuCores = new JSlider(1, cpu.cores());
-			cpuCores.setMajorTickSpacing((int) (step));
+			cpuCores.setMajorTickSpacing((int)(step));
 			cpuCores.setMinorTickSpacing(1);
 			cpuCores.setPaintTicks(true);
 			cpuCores.setPaintLabels(true);
@@ -365,10 +365,10 @@ public class Settings implements Activity {
 		int all_ram = (int) os.getMemory();
 		ram = new JSlider(0, all_ram);
 		int step = 1000000;
-		double display = (double) all_ram / (double) step;
+		double display = (double)all_ram / (double)step;
 		while (display > 10) {
 			step += 1000000;
-			display = (double) all_ram / (double) step;
+			display = (double)all_ram / (double)step;
 		}
 		Hashtable<Integer, JLabel> labelTable = new Hashtable<Integer, JLabel>();
 		for (int g = 0; g < all_ram; g += step) {
@@ -378,7 +378,7 @@ public class Settings implements Activity {
 		ram.setLabelTable(labelTable);
 		ram.setPaintTicks(true);
 		ram.setPaintLabels(true);
-		ram.setValue((int) (config.getMaxMemory() != -1 ? config.getMaxMemory() : os.getMemory()));
+		ram.setValue((int)(config.getMaxMemory() != -1 ? config.getMaxMemory() : os.getMemory()));
 		JLabel ramLabel = new JLabel("Memory:");
 		
 		compute_devices_constraints.weightx = 1.0 / gpus.size();
@@ -405,7 +405,7 @@ public class Settings implements Activity {
 		priority.setPaintTicks(true);
 		priority.setPaintLabels(true);
 		priority.setValue(config.getPriority());
-		JLabel priorityLabel = new JLabel(high_priority_support ? "Priority (High <-> Low):" : "Priority (Normal <-> Low):");
+		JLabel priorityLabel = new JLabel(high_priority_support ? "Priority (High <-> Low):" : "Priority (Normal <-> Low):" );
 		
 		compute_devices_constraints.weightx = 1.0 / gpus.size();
 		compute_devices_constraints.gridx = 0;
@@ -452,7 +452,7 @@ public class Settings implements Activity {
 		if (parent.getConfiguration().getMaxRenderTime() > 0) {
 			val = parent.getConfiguration().getMaxRenderTime() / 60;
 		}
-		renderTime = new JSpinner(new SpinnerNumberModel(val, 0, 1000, 1));
+		renderTime = new JSpinner(new SpinnerNumberModel(val,0,1000,1));
 		
 		advanced_panel.add(renderTimeLabel);
 		advanced_panel.add(renderTime);
@@ -482,7 +482,7 @@ public class Settings implements Activity {
 		
 		currentRow++;
 		constraints.gridy = currentRow;
-		parent.getContentPane().add(new JLabel(" "), constraints);    // Add a separator between last checkboxes and button
+		parent.getContentPane().add(new JLabel(" "), constraints);	// Add a separator between last checkboxes and button
 
 		currentRow++;
 		String buttonText = "Start";
@@ -549,8 +549,7 @@ public class Settings implements Activity {
 		try {
 			if (theme_.equals("light")) {
 				UIManager.setLookAndFeel(new FlatLightLaf());
-			}
-			else if (theme_.equals("dark")) {
+			} else if (theme_.equals("dark")) {
 				UIManager.setLookAndFeel(new FlatDarkLaf());
 			}
 
@@ -660,9 +659,8 @@ public class Settings implements Activity {
 				return;
 			}
 
-			if (themeOptionsGroup.getSelection().getActionCommand() != null) {
+			if (themeOptionsGroup.getSelection().getActionCommand() != null)
 				config.setTheme(themeOptionsGroup.getSelection().getActionCommand());
-			}
 			
 			if (cacheDir != null) {
 				File fromConfig = config.getStorageDir();
@@ -722,7 +720,7 @@ public class Settings implements Activity {
 			
 			int max_rendertime = -1;
 			if (renderTime != null) {
-				max_rendertime = (Integer) renderTime.getValue() * 60;
+				max_rendertime = (Integer)renderTime.getValue() * 60;
 				config.setMaxRenderTime(max_rendertime);
 			}
 			
@@ -769,7 +767,7 @@ public class Settings implements Activity {
 						cachePath,
 						autoSignIn.isSelected(),
 						GuiSwing.type,
-						themeOptionsGroup.getSelection().getActionCommand(),    // selected theme
+						themeOptionsGroup.getSelection().getActionCommand(),	// selected theme
 						priority.getValue()));
 				
 				// wait for successful authentication (to store the public key)

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -110,7 +110,7 @@ public class Settings implements Activity {
 		Configuration config = parent.getConfiguration();
 		new SettingsLoader(config.getConfigFilePath()).merge(config);
 		
-		applyTheme(config.getTheme());	// apply the proper theme (light/dark)
+		applyTheme(config.getTheme());    // apply the proper theme (light/dark)
 
 		List<GPUDevice> gpus = GPU.listDevices(config);
 		useGPUs.clear();    // Empty the auxiliary list (used in the list of checkboxes)
@@ -129,7 +129,7 @@ public class Settings implements Activity {
 		++currentRow;
 		
 		constraints.gridy = currentRow;
-		parent.getContentPane().add(new JLabel(" "), constraints);	// Add a separator between logo and first panel
+		parent.getContentPane().add(new JLabel(" "), constraints);    // Add a separator between logo and first panel
 
 		currentRow++;
 
@@ -328,14 +328,14 @@ public class Settings implements Activity {
 		CPU cpu = new CPU();
 		if (cpu.cores() > 1) { // if only one core is available, no need to show the choice
 			double step = 1;
-			double display = (double)cpu.cores() / step;
+			double display = (double) cpu.cores() / step;
 			while (display > 10) {
 				step += 1.0;
-				display = (double)cpu.cores() / step;
+				display = (double) cpu.cores() / step;
 			}
 			
 			cpuCores = new JSlider(1, cpu.cores());
-			cpuCores.setMajorTickSpacing((int)(step));
+			cpuCores.setMajorTickSpacing((int) (step));
 			cpuCores.setMinorTickSpacing(1);
 			cpuCores.setPaintTicks(true);
 			cpuCores.setPaintLabels(true);
@@ -362,10 +362,10 @@ public class Settings implements Activity {
 		int all_ram = (int) os.getMemory();
 		ram = new JSlider(0, all_ram);
 		int step = 1000000;
-		double display = (double)all_ram / (double)step;
+		double display = (double) all_ram / (double) step;
 		while (display > 10) {
 			step += 1000000;
-			display = (double)all_ram / (double)step;
+			display = (double) all_ram / (double) step;
 		}
 		Hashtable<Integer, JLabel> labelTable = new Hashtable<Integer, JLabel>();
 		for (int g = 0; g < all_ram; g += step) {
@@ -375,7 +375,7 @@ public class Settings implements Activity {
 		ram.setLabelTable(labelTable);
 		ram.setPaintTicks(true);
 		ram.setPaintLabels(true);
-		ram.setValue((int)(config.getMaxMemory() != -1 ? config.getMaxMemory() : os.getMemory()));
+		ram.setValue((int) (config.getMaxMemory() != -1 ? config.getMaxMemory() : os.getMemory()));
 		JLabel ramLabel = new JLabel("Memory:");
 		
 		compute_devices_constraints.weightx = 1.0 / gpus.size();
@@ -402,7 +402,7 @@ public class Settings implements Activity {
 		priority.setPaintTicks(true);
 		priority.setPaintLabels(true);
 		priority.setValue(config.getPriority());
-		JLabel priorityLabel = new JLabel(high_priority_support ? "Priority (High <-> Low):" : "Priority (Normal <-> Low):" );
+		JLabel priorityLabel = new JLabel(high_priority_support ? "Priority (High <-> Low):" : "Priority (Normal <-> Low):");
 		
 		compute_devices_constraints.weightx = 1.0 / gpus.size();
 		compute_devices_constraints.gridx = 0;
@@ -449,7 +449,7 @@ public class Settings implements Activity {
 		if (parent.getConfiguration().getMaxRenderTime() > 0) {
 			val = parent.getConfiguration().getMaxRenderTime() / 60;
 		}
-		renderTime = new JSpinner(new SpinnerNumberModel(val,0,1000,1));
+		renderTime = new JSpinner(new SpinnerNumberModel(val, 0, 1000, 1));
 		
 		advanced_panel.add(renderTimeLabel);
 		advanced_panel.add(renderTime);
@@ -479,7 +479,7 @@ public class Settings implements Activity {
 		
 		currentRow++;
 		constraints.gridy = currentRow;
-		parent.getContentPane().add(new JLabel(" "), constraints);	// Add a separator between last checkboxes and button
+		parent.getContentPane().add(new JLabel(" "), constraints);    // Add a separator between last checkboxes and button
 
 		currentRow++;
 		String buttonText = "Start";
@@ -523,7 +523,8 @@ public class Settings implements Activity {
 		try {
 			if (theme_.equals("light")) {
 				UIManager.setLookAndFeel(new FlatLightLaf());
-			} else if (theme_.equals("dark")) {
+			}
+			else if (theme_.equals("dark")) {
 				UIManager.setLookAndFeel(new FlatDarkLaf());
 			}
 
@@ -613,8 +614,9 @@ public class Settings implements Activity {
 				return;
 			}
 
-			if (themeOptionsGroup.getSelection().getActionCommand() != null)
+			if (themeOptionsGroup.getSelection().getActionCommand() != null) {
 				config.setTheme(themeOptionsGroup.getSelection().getActionCommand());
+			}
 			
 			if (cacheDir != null) {
 				File fromConfig = config.getStorageDir();
@@ -674,7 +676,7 @@ public class Settings implements Activity {
 			
 			int max_rendertime = -1;
 			if (renderTime != null) {
-				max_rendertime = (Integer)renderTime.getValue() * 60;
+				max_rendertime = (Integer) renderTime.getValue() * 60;
 				config.setMaxRenderTime(max_rendertime);
 			}
 			
@@ -721,7 +723,7 @@ public class Settings implements Activity {
 						cachePath,
 						autoSignIn.isSelected(),
 						GuiSwing.type,
-						themeOptionsGroup.getSelection().getActionCommand(),	// selected theme
+						themeOptionsGroup.getSelection().getActionCommand(),    // selected theme
 						priority.getValue()));
 				
 				// wait for successful authentication (to store the public key)


### PR DESCRIPTION
This feature allows the user to configure the default GPU render bucket size (aka render tile size).

Interestingly, the fastest render time for CPU is the slowest on the GPU. This due to the GPU only being able to render one tile at a time, so it doesn't benefit from more tiles, but for being able to calculate more information and minimise the transfers between the GPU and the main CPU/memory.

Depending on the GPU, the maximum render bucket size will be 512x512 pixel on CUDA GPUs or 2048x2048 pixel on OPENCL ones (yes, AMD cards really love huge render bucket sizes!!!). The minimum size remains in 32x32 pixel for both GPU and CPU.

The configuration can be done via the Settings screen in the GUI or thru the _-renderbucket-size_ option in the command line.

Screenshot:
![image](https://user-images.githubusercontent.com/4283528/80585100-173e4980-8a56-11ea-9372-52bfe9f29cf3.png)
