### PR TITLE
Fix: racing condition with error messages when the queue is full

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -358,12 +358,15 @@ public class Client {
 						this.renderingJob = null;
 					}
 					
-					while (this.shouldWaitBeforeRender() == true) {
-						try {
-							Thread.sleep(4000); // wait a little bit
-							this.gui.status("Sending frames. Please wait");
-						}
-						catch (InterruptedException e3) {
+					if (this.shouldWaitBeforeRender() == true) {
+						this.gui.status("Sending frames. Please wait");
+						
+						while (this.shouldWaitBeforeRender() == true) {
+							try {
+								Thread.sleep(4000); // wait a little bit
+							}
+							catch (InterruptedException e3) {
+							}
 						}
 					}
 					this.log.removeCheckPoint(step);

--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -206,7 +206,7 @@ public class GuiSwing extends JFrame implements Gui {
 	
 	@Override
 	public void error(String msg_) {
-		status(msg_);
+		status(msg_, true);
 	}
 	
 	@Override


### PR DESCRIPTION
There was a racing condition between the queue full message and **any** error message where the later are overwritten by the former. Modified so the error messages are always shown in the client, regardless of the client status.