### PR TITLE
Fix: ugly JavaException when error generating thumbnail in GUI

### DIFF
--- a/src/com/sheepit/client/standalone/swing/activity/Working.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Working.java
@@ -47,6 +47,7 @@ import javax.swing.SpringLayout;
 
 import com.sheepit.client.Client;
 import com.sheepit.client.Job;
+import com.sheepit.client.Log;
 import com.sheepit.client.Stats;
 import com.sheepit.client.Utils;
 import com.sheepit.client.standalone.GuiSwing;
@@ -75,6 +76,7 @@ public class Working implements Activity {
 	private JLabel user_info_total_rendertime_this_session_value;
 	private JLabel userInfoQueuedUploadsAndSizeValue;
 	private String currentTheme;
+	private Log log;
 	
 	public Working(GuiSwing parent_) {
 		parent = parent_;
@@ -97,6 +99,7 @@ public class Working implements Activity {
 		userInfoQueuedUploadsAndSizeValue = new JLabel("0");
 		currentTheme = UIManager.getLookAndFeel().getName();    // Capture the theme on component instantiation
 		previousStatus = "";
+		log = Log.getInstance(parent_.getConfiguration());
 	}
 	
 	@Override
@@ -382,8 +385,9 @@ public class Working implements Activity {
 						icon = new ImageIcon(img.getScaledInstance((int) (width * factor), (int) (height * factor), Image.SCALE_FAST));
 					}
 					catch (IOException e) {
-						System.out.println("Working::showLastRender() exception " + e);
-						e.printStackTrace();
+						log.error(String.format("Working::showLastRender() Unable to load/preview rendered frame [%s]. Exception %s",
+								lastJob.getOutputImagePath(),
+								e.getMessage()));
 					}
 				}
 


### PR DESCRIPTION
When a rendered frame cannot be read, the following Java IIOException is showed on the screen or console:

_JavaException when failing to generate thumbnail in SWING client:: (v6.1714) Working::showLastRender() exception javax.imageio.IIOException: Can't read input file! javax.imageio.IIOException: Can't read input file! at javax.imageio.ImageIO.read(Unknown Source) at com.sheepit.client.standalone.swing.activity.Working.showLastRender(Working.java:372) at com.sheepit.client.standalone.swing.activity.Working.setRenderedFrame(Working.java:352) at com.sheepit.client.standalone.GuiSwing.AddFrameRendered(GuiSwing.java:231) at com.sheepit.client.Client.confirmJob(Client.java:830) at com.sheepit.client.Client.senderLoop(Client.java:471) at com.sheepit.client.Client$1.run(Client.java:132) at java.lang.Thread.run(Unknown Source)_

The error is now sent to the proper log error channel. 
