### PR TITLE
Fix: remove the ALCplaybackAlsa_open error message when rendering

### DIFF
--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -249,6 +249,11 @@ public class Job {
 			}
 		}
 		
+		// Add this option to the blender call to remove the following execution errors:
+		//		ALSA lib pcm_dmix.c:1108:(snd_pcm_dmix_open) unable to open slave
+		// 		AL lib: (EE) ALCplaybackAlsa_open: Could not open playback device 'default': No such file or directory
+		command.add("-noaudio");
+		
 		try {
 			renderStartedObservable event = new renderStartedObservable(renderStarted);
 			String line;


### PR DESCRIPTION
Remove the following errors generated at the start of the rendering process by adding the _-noaudio_ option to the rend.exe call.

ALSA lib pcm_dmix.c:1108:(snd_pcm_dmix_open) unable to open slave
AL lib: (EE) ALCplaybackAlsa_open: Could not open playback device 'default': No such file or directory