### PR TITLE
Fix: app randomly hangs when the upload queue is full

### DIFF
--- a/src/com/sheepit/client/Log.java
+++ b/src/com/sheepit/client/Log.java
@@ -55,14 +55,21 @@ public class Log {
 	}
 	
 	private void append(String level_, String msg_) {
-		if (msg_.equals("") == false) {
-			String line = this.dateFormat.format(new java.util.Date()) + " (" + level_ + ") " + msg_;
-			if (this.checkpoints.containsKey(this.lastCheckPoint) && this.checkpoints.get(this.lastCheckPoint) != null) {
-				this.checkpoints.get(this.lastCheckPoint).add(line);
+		String line = null;
+		
+		try {
+			if (msg_.equals("") == false) {
+				line = this.dateFormat.format(new java.util.Date()) + " (" + level_ + ") " + msg_;
+				if (this.checkpoints.containsKey(this.lastCheckPoint) && this.checkpoints.get(this.lastCheckPoint) != null) {
+					this.checkpoints.get(this.lastCheckPoint).add(line);
+				}
+				if (this.printStdOut == true) {
+					System.out.println(line);
+				}
 			}
-			if (this.printStdOut == true) {
-				System.out.println(line);
-			}
+		}
+		catch (Exception e) {
+			// Nothing to do here. Just allow the thread to continue
 		}
 	}
 	


### PR DESCRIPTION
This not a definitive fix but a proper workaround to ensure the app is not getting randomly frozen when the upload queue is full.
There is a race condition in the way the app execution snapshots are managed. We will review/improve the whole snapshots process but in the meanwhile, this should keep the client from getting frozen.