### PR TITLE
Fix: functionality to set the client priority not working properly

### DIFF
--- a/src/com/sheepit/client/os/FreeBSD.java
+++ b/src/com/sheepit/client/os/FreeBSD.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.io.BufferedReader;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 
 import com.sheepit.client.Log;
@@ -31,11 +32,10 @@ import com.sheepit.client.hardware.cpu.CPU;
 
 public class FreeBSD extends OS {
 	private final String NICE_BINARY_PATH = "nice";
-	private Boolean hasNiceBinary;
+	private final String ID_COMMAND_INVOCATION = "id -u";
 	
 	public FreeBSD() {
 		super();
-		this.hasNiceBinary = null;
 	}
 	
 	public String name() {
@@ -155,10 +155,7 @@ public class FreeBSD extends OS {
 		}
 		
 		List<String> actual_command = command;
-		if (this.hasNiceBinary == null) {
-			this.checkNiceAvailability();
-		}
-		if (this.hasNiceBinary.booleanValue()) {
+		if (checkNiceAvailability()) {
 			// launch the process in lowest priority
 			if (env_overight != null) {
 				actual_command.add(0, env_overight.get("PRIORITY"));
@@ -183,17 +180,42 @@ public class FreeBSD extends OS {
 		return builder.start();
 	}
 	
-	private void checkNiceAvailability() {
+	@Override public boolean getSupportHighPriority() {
+		try {
+			ProcessBuilder builder = new ProcessBuilder();
+			builder.command("bash", "-c", ID_COMMAND_INVOCATION);
+			builder.redirectErrorStream(true);
+			
+			Process process = builder.start();
+			InputStream is = process.getInputStream();
+			BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+			
+			String userLevel = null;
+			if ((userLevel = reader.readLine()) != null) {
+				// Root user in *ix systems -independently of the alias used to login- has a id value of 0. On top of being a user with root capabilities,
+				// to support changing the priority the nice tool must be accessible from the current user
+				return (userLevel.equals("0")) & checkNiceAvailability();
+			}
+		}
+		catch (IOException e) {
+			System.err.println(String.format("ERROR FreeBSD::getSupportHighPriority Unable to execute id command. IOException %s", e.getMessage()));
+		}
+		
+		return false;
+	}
+	
+	@Override public boolean checkNiceAvailability() {
 		ProcessBuilder builder = new ProcessBuilder();
 		builder.command(NICE_BINARY_PATH);
 		builder.redirectErrorStream(true);
+		
 		Process process = null;
+		boolean hasNiceBinary = false;
 		try {
 			process = builder.start();
-			this.hasNiceBinary = true;
+			hasNiceBinary = true;
 		}
 		catch (IOException e) {
-			this.hasNiceBinary = false;
 			Log.getInstance(null).error("Failed to find low priority binary, will not launch renderer in normal priority (" + e + ")");
 		}
 		finally {
@@ -201,5 +223,6 @@ public class FreeBSD extends OS {
 				process.destroy();
 			}
 		}
+		return hasNiceBinary;
 	}
 }

--- a/src/com/sheepit/client/os/OS.java
+++ b/src/com/sheepit/client/os/OS.java
@@ -41,9 +41,9 @@ public abstract class OS {
 		return null;
 	}
 	
-	public boolean getSupportHighPriority() {
-		return true;
-	}
+	public abstract boolean getSupportHighPriority();
+	
+	public abstract boolean checkNiceAvailability();
 	
 	public Process exec(List<String> command, Map<String, String> env) throws IOException {
 		ProcessBuilder builder = new ProcessBuilder(command);

--- a/src/com/sheepit/client/os/Windows.java
+++ b/src/com/sheepit/client/os/Windows.java
@@ -218,4 +218,13 @@ public class Windows extends OS {
 		}
 		return false;
 	}
+	
+	@Override public boolean getSupportHighPriority() {
+		return true;
+	}
+	
+	@Override public boolean checkNiceAvailability() {
+		// In windows, nice is not required and therefore we return always true to show the slider in the Settings GUI
+		return true;
+	}
 }

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -406,6 +406,10 @@ public class Settings implements Activity {
 		priority.setValue(config.getPriority());
 		JLabel priorityLabel = new JLabel(high_priority_support ? "Priority (High <-> Low):" : "Priority (Normal <-> Low):");
 		
+		boolean showPrioritySlider = os.checkNiceAvailability();
+		priority.setVisible(showPrioritySlider);
+		priorityLabel.setVisible(showPrioritySlider);
+		
 		compute_devices_constraints.weightx = 1.0 / gpus.size();
 		compute_devices_constraints.gridx = 0;
 		compute_devices_constraints.gridy++;


### PR DESCRIPTION
A couple of bugs fixed with this PR:
1. In *nix-based OS, the priority is set using the _nice_ tool, but the Settings window allows you to define the priority even if the tool is non-existent. The Settings window now remove the _Priority_ slider if the tool is not available in the system.
2. The routine to detect if the user in the OS session user has enough rights to increase the priority of the client was returning always true. With this PR, the routine checks two things: a) that the user has enough rights to increase the priority (root and sudo's) via _id_ command and; b) that the _nice_ tool exists.