### PR TITLE
Feature: minimize to SysTray option on the settings screen

### DIFF
--- a/src/com/sheepit/client/Configuration.java
+++ b/src/com/sheepit/client/Configuration.java
@@ -62,6 +62,7 @@ import lombok.Data;
 	private List<Pair<Calendar, Calendar>> requestTime;
 	private String extras;
 	private boolean autoSignIn;
+	private boolean useSysTray;
 	private String UIType;
 	private String hostname;
 	private String theme;
@@ -90,6 +91,7 @@ import lombok.Data;
 		this.requestTime = null;
 		this.extras = "";
 		this.autoSignIn = false;
+		this.useSysTray = true;
 		this.UIType = null;
 		this.theme = null;
 	}

--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -54,6 +54,7 @@ public class SettingsLoader {
 	private String renderTime;
 	private String cacheDir;
 	private String autoSignIn;
+	private String useSysTray;
 	private String ui;
 	private String theme;
 	private int priority;
@@ -68,8 +69,8 @@ public class SettingsLoader {
 	}
 	
 	public SettingsLoader(String path_, String login_, String password_, String proxy_, String hostname_, ComputeType computeMethod_, GPUDevice gpu_,
-			int renderbucketSize_, int cores_, long maxRam_, int maxRenderTime_, String cacheDir_, boolean autoSignIn_, String ui_, String theme_,
-			int priority_) {
+		int renderbucketSize_, int cores_, long maxRam_, int maxRenderTime_, String cacheDir_, boolean autoSignIn_, boolean useSysTray_, String ui_,
+		String theme_, int priority_) {
 		if (path_ == null) {
 			path = getDefaultFilePath();
 		}
@@ -82,6 +83,7 @@ public class SettingsLoader {
 		hostname = hostname_;
 		cacheDir = cacheDir_;
 		autoSignIn = String.valueOf(autoSignIn_);
+		useSysTray = String.valueOf(useSysTray_);
 		ui = ui_;
 		priority = priority_;
 		theme = theme_;
@@ -175,6 +177,10 @@ public class SettingsLoader {
 				prop.setProperty("auto-signin", autoSignIn);
 			}
 			
+			if (useSysTray != null) {
+				prop.setProperty("use-systray", useSysTray);
+			}
+			
 			if (ui != null) {
 				prop.setProperty("ui", ui);
 			}
@@ -225,6 +231,7 @@ public class SettingsLoader {
 		this.renderbucketSize = null;
 		this.cacheDir = null;
 		this.autoSignIn = null;
+		this.useSysTray = null;
 		this.ui = null;
 		this.priority = 19; // must be the same default as Configuration
 		this.ram = null;
@@ -293,6 +300,10 @@ public class SettingsLoader {
 				this.autoSignIn = prop.getProperty("auto-signin");
 			}
 			
+			if (prop.containsKey("use-systray")) {
+				this.useSysTray = prop.getProperty("use-systray");
+			}
+			
 			if (prop.containsKey("ui")) {
 				this.ui = prop.getProperty("ui");
 			}
@@ -351,7 +362,7 @@ public class SettingsLoader {
 		}
 		try {
 			if ((config.getComputeMethod() == null && computeMethod != null) || (computeMethod != null && config.getComputeMethod() != ComputeType
-					.valueOf(computeMethod))) {
+				.valueOf(computeMethod))) {
 				config.setComputeMethod(ComputeType.valueOf(computeMethod));
 			}
 		}
@@ -413,11 +424,18 @@ public class SettingsLoader {
 			}
 		}
 		
-		config.setAutoSignIn(Boolean.valueOf(autoSignIn));
+		// if the user has invoked the app with --no-systray, then we just overwrite the existing configuration with (boolean)false. If no parameter has been
+		// specified and the settings file contains use-systray=false, then deactivate as well.
+		if (!config.isUseSysTray() || (config.isUseSysTray() && useSysTray != null && useSysTray.equals("false"))) {
+			config.setUseSysTray(false);
+		}
+		
+		config.setAutoSignIn(Boolean.parseBoolean(autoSignIn));
 	}
 	
 	@Override public String toString() {
-		return "SettingsLoader [path=" + path + ", login=" + login + ", password=" + password + ", computeMethod=" + computeMethod + ", gpu=" + gpu
-				+ ", renderbucket-size=" + renderbucketSize + ", cacheDir=" + cacheDir + ", theme=" + theme + ", priority=" + priority + "]";
+		return String.format(
+			"SettingsLoader [path=%s, login=%s, password=%s, computeMethod=%s, gpu=%s, renderbucket-size=%s, cacheDir=%s, theme=%s, priority=%d, autosign=%s, usetray=%s]",
+			path, login, password, computeMethod, gpu, renderbucketSize, cacheDir, theme, priority, autoSignIn, useSysTray);
 	}
 }

--- a/src/com/sheepit/client/standalone/Worker.java
+++ b/src/com/sheepit/client/standalone/Worker.java
@@ -84,7 +84,7 @@ public class Worker {
 	
 	@Option(name = "--show-gpu", usage = "Print available CUDA devices and exit", required = false, handler = ListGpuParameterHandler.class) private ListGpuParameterHandler listGpuParameterHandler;
 	
-	@Option(name = "--no-systray", usage = "Don't use systray", required = false) private boolean no_systray = false;
+	@Option(name = "--no-systray", usage = "Don't use SysTray", required = false) private boolean useSysTray = false;
 	
 	@Option(name = "-priority", usage = "Set render process priority (19 lowest to -19 highest)", required = false) private int priority = 19;
 	
@@ -132,6 +132,11 @@ public class Worker {
 		// the 4th concurrent job is requested and that will put the client in "wait" mode for some random time. To
 		// avoid that situation we set this limit.
 		config.setMaxUploadingJob(3);
+		
+		// Store the SysTray preference from the user. Please note that we must ! the value of the variable because the way args4j works. If the --no-systray
+		// parameter is detected, args4j will store (boolean)true in the useSysTray variable but we want to store (boolean)false in the configuration class
+		// for further checks.
+		config.setUseSysTray(!useSysTray);
 		
 		if (gpu_device != null) {
 			if (gpu_device.startsWith(Nvidia.TYPE) == false && gpu_device.startsWith(OpenCL.TYPE) == false) {
@@ -287,9 +292,9 @@ public class Worker {
 				System.exit(2);
 			}
 			config.setConfigFilePath(config_file);
-			new SettingsLoader(config_file).merge(config);
 		}
 		
+		new SettingsLoader(config_file).merge(config);
 		Log.getInstance(config).debug("client version " + config.getJarVersion());
 		
 		Gui gui;
@@ -316,7 +321,7 @@ public class Worker {
 					System.err.println("Please use one of the text-based UIs provided (using -ui " + GuiTextOneLine.type + " or -ui " + GuiText.type + ")");
 					System.exit(3);
 				}
-				gui = new GuiSwing(no_systray == false, title);
+				gui = new GuiSwing(config.isUseSysTray(), title);
 				break;
 		}
 		Client cli = new Client(gui, config, server);

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -85,6 +85,7 @@ public class Settings implements Activity {
 	private JFileChooser cacheDirChooser;
 	private JCheckBox useCPU;
 	private List<JCheckBoxGPU> useGPUs;
+	private JCheckBox useSysTray;
 	private JLabel renderbucketSizeLabel;
 	private JSlider renderbucketSize;
 	private JSlider cpuCores;
@@ -103,6 +104,7 @@ public class Settings implements Activity {
 	JButton saveButton;
 	
 	private boolean haveAutoStarted;
+	private boolean useSysTrayPrevState;
 	
 	public Settings(GuiSwing parent_) {
 		parent = parent_;
@@ -114,6 +116,7 @@ public class Settings implements Activity {
 	@Override public void show() {
 		Configuration config = parent.getConfiguration();
 		new SettingsLoader(config.getConfigFilePath()).merge(config);
+		useSysTrayPrevState = config.isUseSysTray();
 		
 		applyTheme(config.getTheme());    // apply the proper theme (light/dark)
 		
@@ -450,8 +453,15 @@ public class Settings implements Activity {
 		parent.getContentPane().add(compute_devices_panel, constraints);
 		
 		// other
-		CollapsibleJPanel advanced_panel = new CollapsibleJPanel(new GridLayout(3, 2));
+		CollapsibleJPanel advanced_panel = new CollapsibleJPanel(new GridLayout(4, 2));
 		advanced_panel.setBorder(BorderFactory.createTitledBorder("Advanced options"));
+		
+		JLabel useSysTrayLabel = new JLabel("Minimise to SysTray");
+		
+		useSysTray = new JCheckBox();
+		useSysTray.setSelected(config.isUseSysTray());
+		advanced_panel.add(useSysTrayLabel);
+		advanced_panel.add(useSysTray);
 		
 		JLabel proxyLabel = new JLabel("Proxy:");
 		proxyLabel.setToolTipText("http://login:password@host:port");
@@ -485,7 +495,6 @@ public class Settings implements Activity {
 		constraints.gridy = currentRow;
 		constraints.gridwidth = 2;
 		parent.getContentPane().add(advanced_panel, constraints);
-		advanced_panel.setCollapsed(true);
 		
 		// general settings
 		JPanel general_panel = new JPanel(new GridLayout(1, 2));
@@ -522,6 +531,9 @@ public class Settings implements Activity {
 		constraints.gridx = 0;
 		constraints.gridy = currentRow;
 		parent.getContentPane().add(saveButton, constraints);
+
+		// Increase the size of the app Window to ensure it shows all the information with the Advanced Options panel opened.
+		parent.setSize(520,850);
 		
 		if (haveAutoStarted == false && config.isAutoSignIn() && checkDisplaySaveButton()) {
 			// auto start
@@ -774,14 +786,17 @@ public class Settings implements Activity {
 			if (saveFile.isSelected()) {
 				parent.setSettingsLoader(
 						new SettingsLoader(config.getConfigFilePath(), login.getText(), new String(password.getPassword()), proxyText, hostnameText, method,
-								selected_gpu, renderbucket_size, cpu_cores, max_ram, max_rendertime, cachePath, autoSignIn.isSelected(), GuiSwing.type,
-								themeOptionsGroup.getSelection().getActionCommand(),    // selected theme
-								priority.getValue()));
+								selected_gpu, renderbucket_size, cpu_cores, max_ram, max_rendertime, cachePath, autoSignIn.isSelected(), useSysTray.isSelected(),
+								GuiSwing.type, themeOptionsGroup.getSelection().getActionCommand(), priority.getValue()));
 				
 				// wait for successful authentication (to store the public key)
 				// or do we already have one?
 				if (parent.getClient().getServer().getServerConfig() != null && parent.getClient().getServer().getServerConfig().getPublickey() != null) {
 					parent.getSettingsLoader().saveFile();
+				}
+				
+				if (useSysTrayPrevState != useSysTray.isSelected()) {
+					JOptionPane.showMessageDialog(null, "You must restart the SheepIt app for the SysTray change to take effect");
 				}
 			}
 		}

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -456,7 +456,7 @@ public class Settings implements Activity {
 		CollapsibleJPanel advanced_panel = new CollapsibleJPanel(new GridLayout(4, 2));
 		advanced_panel.setBorder(BorderFactory.createTitledBorder("Advanced options"));
 		
-		JLabel useSysTrayLabel = new JLabel("Minimise to SysTray");
+		JLabel useSysTrayLabel = new JLabel("Minimize to SysTray");
 		
 		useSysTray = new JCheckBox();
 		useSysTray.setSelected(config.isUseSysTray());

--- a/src/com/sheepit/client/standalone/swing/activity/Working.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Working.java
@@ -261,6 +261,9 @@ public class Working implements Activity {
 		alignPanel(current_project_panel, 5, 2, widthLeftColumn);
 		alignPanel(global_stats_panel, 4, 2, widthLeftColumn);
 		alignPanel(session_info_panel, 5, 2, widthLeftColumn);
+		
+		// Set the proper size for the Working (if coming from Settings screen, the window size will be too big for the content!)
+		parent.setSize(520, 760);
 	}
 	
 	public void setStatus(String msg_) {


### PR DESCRIPTION
This PR adds a new configuration option (_Minimise to SysTray_) to the Settings screen. The existing
 `--no-systray` parameter still exists and, if present, overwrites the value stored in the configuration file.

Screenshot:
![image](https://user-images.githubusercontent.com/4283528/83872983-5149ec00-a776-11ea-806b-85e84fe04a9d.png)
