### PR TITLE
Remove the 5 minutes wait for the RENDERER_KILLED_BY_USER_OVER_TIME

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -568,7 +568,7 @@ import lombok.Data;
 		}
 		
 		if (error != null && (error == Error.Type.RENDERER_CRASHED || error == Error.Type.RENDERER_KILLED_BY_USER
-				|| error == Error.Type.RENDERER_KILLED_BY_SERVER)) {
+				|| error == Type.RENDERER_KILLED_BY_USER_OVER_TIME || error == Error.Type.RENDERER_KILLED_BY_SERVER)) {
 			// do nothing, we can ask for a job right away
 		}
 		else {


### PR DESCRIPTION
In case of error, the app waits five minutes to request a new job. There are three exceptions to this rule: the `RENDERER_CRASHED`, `RENDERER_KILLED_BY_USER` and `RENDERER_KILLED_BY_SERVER` errors, where the client requests a new job immediately. 

This PR adds the `RENDERER_KILLED_BY_USER_OVER_TIME` error to the no-wait list.