### PR TITLE
Fix: Job killed by time limit is wrongly catalogued as NO_FILE_OUTPUT

### DIFF
--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -280,9 +280,9 @@ import lombok.Getter;
 						if (process != null) {
 							long duration = (new Date().getTime() - process.getStartTime()) / 1000; // in seconds
 							if (configuration.getMaxRenderTime() > 0 && duration > configuration.getMaxRenderTime()) {
+								setAskForRendererKill(true);
 								log.debug("Killing render because process duration");
 								OS.getOS().kill(process.getProcess());
-								setAskForRendererKill(true);
 							}
 						}
 					}


### PR DESCRIPTION
As the value of the `askForRendererKill` flag is set right after the return of the killing process, under some particular memory and system load circumstances, a race condition occurs and the main thread (reading the Blender output) closes the process faster than the `process.destroy()` returns the control to the Timer thread. 

If that condition occurs, the `isAskForRendererKill()` check returns false (the flag hasn't been set to _true_ in the separate thread) and the execution continues with the frame output check (that doesn't exist as the rendering process was interrupted). The final outcome is a wrong _NO_FILE_OUTPUT_ error instead of the proper _RENDERER_KILLED_BY_USER_OVER_TIME_.

The fix has been setting the `askForRendererKill` flag to true before the process is destroyed. If the racing condition occurs, the flag will be correctly set.
