### PR TITLE
Fix: -renderbucket-size value not applied to GPU render

### DIFF
--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -45,6 +45,7 @@ import java.util.regex.Matcher;
 
 import com.sheepit.client.Configuration.ComputeType;
 import com.sheepit.client.Error.Type;
+import com.sheepit.client.hardware.cpu.CPU;
 import com.sheepit.client.hardware.gpu.GPUDevice;
 import com.sheepit.client.hardware.gpu.opencl.OpenCL;
 import com.sheepit.client.os.OS;
@@ -184,7 +185,7 @@ import lombok.Getter;
 		else {
 			// Otherwise (CPU), fix the tile size to 32x32px
 			core_script = "sheepit_set_compute_device(\"NONE\", \"CPU\", \"CPU\")\n";
-			core_script += String.format("bpy.context.scene.render.tile_x = %1$d\nbpy.context.scene.render.tile_y = %1$d\n", 32);
+			core_script += String.format("bpy.context.scene.render.tile_x = %1$d\nbpy.context.scene.render.tile_y = %1$d\n", CPU.MIN_RENDERBUCKET_SIZE);
 			gui.setComputeMethod("CPU");
 		}
 		

--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -38,7 +38,6 @@ import com.sheepit.client.hardware.gpu.GPUDevice;
 import lombok.Setter;
 
 public class SettingsLoader {
-	final private int MIN_RENDERBUCKET_SIZE = 32;
 	private String path;
 	
 	private String login;
@@ -110,7 +109,7 @@ public class SettingsLoader {
 			gpu = gpu_.getId();
 		}
 		
-		if (renderbucketSize_ >= 32) {
+		if (renderbucketSize_ >= GPU.MIN_RENDERBUCKET_SIZE) {
 			renderbucketSize = String.valueOf(renderbucketSize_);
 		}
 	}
@@ -383,7 +382,7 @@ public class SettingsLoader {
 				config.setGPUDevice(device);
 				
 				// If the user has indicated a render bucket size at least 32x32 px, overwrite the config file value
-				if (config.getRenderbucketSize() >= MIN_RENDERBUCKET_SIZE) {
+				if (config.getRenderbucketSize() >= GPU.MIN_RENDERBUCKET_SIZE) {
 					config.getGPUDevice().setRenderbucketSize(config.getRenderbucketSize());    // Update size
 				}
 				else {
@@ -404,7 +403,7 @@ public class SettingsLoader {
 		else if (config.getGPUDevice() != null) {
 			// The order of conditions is important to ensure the priority or app arguments, then the config file and finally the recommended size (if none
 			// specified or already in config file).
-			if (config.getRenderbucketSize() >= MIN_RENDERBUCKET_SIZE) {
+			if (config.getRenderbucketSize() >= GPU.MIN_RENDERBUCKET_SIZE) {
 				config.getGPUDevice().setRenderbucketSize(config.getRenderbucketSize());
 			}
 			else if (renderbucketSize != null) {

--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -38,6 +38,7 @@ import com.sheepit.client.hardware.gpu.GPUDevice;
 import lombok.Setter;
 
 public class SettingsLoader {
+	final private int MIN_RENDERBUCKET_SIZE = 32;
 	private String path;
 	
 	private String login;
@@ -382,7 +383,7 @@ public class SettingsLoader {
 				config.setGPUDevice(device);
 				
 				// If the user has indicated a render bucket size at least 32x32 px, overwrite the config file value
-				if (config.getRenderbucketSize() >= 32) {
+				if (config.getRenderbucketSize() >= MIN_RENDERBUCKET_SIZE) {
 					config.getGPUDevice().setRenderbucketSize(config.getRenderbucketSize());    // Update size
 				}
 				else {
@@ -398,6 +399,19 @@ public class SettingsLoader {
 				
 				// And now update the client configuration with the new value
 				config.setRenderbucketSize(config.getGPUDevice().getRenderbucketSize());
+			}
+		}
+		else if (config.getGPUDevice() != null) {
+			// The order of conditions is important to ensure the priority or app arguments, then the config file and finally the recommended size (if none
+			// specified or already in config file).
+			if (config.getRenderbucketSize() >= MIN_RENDERBUCKET_SIZE) {
+				config.getGPUDevice().setRenderbucketSize(config.getRenderbucketSize());
+			}
+			else if (renderbucketSize != null) {
+				config.getGPUDevice().setRenderbucketSize(Integer.parseInt(renderbucketSize));
+			}
+			else {
+				config.getGPUDevice().setRenderbucketSize(config.getGPUDevice().getRecommendedBucketSize());
 			}
 		}
 		

--- a/src/com/sheepit/client/hardware/cpu/CPU.java
+++ b/src/com/sheepit/client/hardware/cpu/CPU.java
@@ -20,6 +20,7 @@
 package com.sheepit.client.hardware.cpu;
 
 public class CPU {
+	final public static int MIN_RENDERBUCKET_SIZE = 32;
 	private String name;
 	private String model;
 	private String family;

--- a/src/com/sheepit/client/hardware/gpu/GPU.java
+++ b/src/com/sheepit/client/hardware/gpu/GPU.java
@@ -29,6 +29,7 @@ import com.sheepit.client.os.OS;
 import com.sheepit.client.os.Windows;
 
 public class GPU {
+	final public static int MIN_RENDERBUCKET_SIZE = 32;
 	public static List<GPUDevice> devices = null;
 	
 	public static boolean generate() {

--- a/src/com/sheepit/client/hardware/gpu/GPUDevice.java
+++ b/src/com/sheepit/client/hardware/gpu/GPUDevice.java
@@ -37,7 +37,7 @@ public class GPUDevice {
 		this.model = model;
 		this.memory = ram;
 		this.id = id;
-		this.renderBucketSize = 32;
+		this.renderBucketSize = GPU.MIN_RENDERBUCKET_SIZE;;
 	}
 	
 	public GPUDevice(String type, String model, long ram, String id, String oldId) {
@@ -95,7 +95,6 @@ public class GPUDevice {
 	}
 	
 	public void setRenderbucketSize(Integer proposedRenderbucketSize) {
-		int renderBucketSize = 32;
 		GPULister gpu;
 		
 		if (type.equals("CUDA")) {
@@ -109,14 +108,16 @@ public class GPUDevice {
 			// because is a new one (different from CUDA and OPENCL). In that case, move into the safest position
 			// of 32x32 pixel tile sizes
 			System.out.println("GPUDevice::setRenderbucketSize Unable to detect GPU technology. Render bucket size set to 32x32 pixels");
-			this.renderBucketSize = 32;
+			this.renderBucketSize = GPU.MIN_RENDERBUCKET_SIZE;
 			return;
 		}
+		
+		int renderBucketSize = GPU.MIN_RENDERBUCKET_SIZE;;
 		
 		if (proposedRenderbucketSize == null) {
 			renderBucketSize = gpu.getRecommendedRenderBucketSize(getMemory());
 		}
-		else if (proposedRenderbucketSize >= 32) {
+		else if (proposedRenderbucketSize >= GPU.MIN_RENDERBUCKET_SIZE) {
 			if (proposedRenderbucketSize <= gpu.getMaximumRenderBucketSize(getMemory())) {
 				renderBucketSize = proposedRenderbucketSize;
 			}

--- a/src/com/sheepit/client/hardware/gpu/GPUDevice.java
+++ b/src/com/sheepit/client/hardware/gpu/GPUDevice.java
@@ -88,8 +88,13 @@ public class GPUDevice {
 	public int getRenderbucketSize() {
 		return this.renderBucketSize;
 	}
+
+	public int getRecommendedBucketSize() {
+		this.setRenderbucketSize(null);
+		return this.renderBucketSize;
+	}
 	
-	public void setRenderbucketSize(int proposedRenderbucketSize) {
+	public void setRenderbucketSize(Integer proposedRenderbucketSize) {
 		int renderBucketSize = 32;
 		GPULister gpu;
 		
@@ -108,7 +113,10 @@ public class GPUDevice {
 			return;
 		}
 		
-		if (proposedRenderbucketSize >= 32) {
+		if (proposedRenderbucketSize == null) {
+			renderBucketSize = gpu.getRecommendedRenderBucketSize(getMemory());
+		}
+		else if (proposedRenderbucketSize >= 32) {
 			if (proposedRenderbucketSize <= gpu.getMaximumRenderBucketSize(getMemory())) {
 				renderBucketSize = proposedRenderbucketSize;
 			}

--- a/src/com/sheepit/client/hardware/gpu/GPUDevice.java
+++ b/src/com/sheepit/client/hardware/gpu/GPUDevice.java
@@ -37,7 +37,7 @@ public class GPUDevice {
 		this.model = model;
 		this.memory = ram;
 		this.id = id;
-		this.renderBucketSize = GPU.MIN_RENDERBUCKET_SIZE;;
+		this.renderBucketSize = GPU.MIN_RENDERBUCKET_SIZE;
 	}
 	
 	public GPUDevice(String type, String model, long ram, String id, String oldId) {
@@ -112,7 +112,7 @@ public class GPUDevice {
 			return;
 		}
 		
-		int renderBucketSize = GPU.MIN_RENDERBUCKET_SIZE;;
+		int renderBucketSize = GPU.MIN_RENDERBUCKET_SIZE;
 		
 		if (proposedRenderbucketSize == null) {
 			renderBucketSize = gpu.getRecommendedRenderBucketSize(getMemory());

--- a/src/com/sheepit/client/standalone/Worker.java
+++ b/src/com/sheepit/client/standalone/Worker.java
@@ -266,7 +266,7 @@ public class Worker {
 		config.setComputeMethod(compute_method);
 		
 		// Change the default configuration if the user has specified a minimum renderbucket size of 32
-		if (renderbucketSize >= 32) {
+		if (renderbucketSize >= GPU.MIN_RENDERBUCKET_SIZE) {
 			// Send the proposed renderbucket size and check if viable
 			config.setRenderbucketSize(renderbucketSize);
 		}

--- a/src/com/sheepit/client/standalone/swing/activity/Settings.java
+++ b/src/com/sheepit/client/standalone/swing/activity/Settings.java
@@ -314,7 +314,7 @@ public class Settings implements Activity {
 			// because is a new one (different from CUDA and OPENCL). In that case, move into a safe position
 			// of 32x32 pixel render bucket and a maximum of 128x128 pixel for the "unknown GPU"
 			int maxRenderbucketSize = 128;
-			int recommendedBucketSize = 32;
+			int recommendedBucketSize = GPU.MIN_RENDERBUCKET_SIZE;
 			
 			if (config.getComputeMethod() == ComputeType.GPU || config.getComputeMethod() == ComputeType.CPU_GPU) {
 				GPULister gpu;
@@ -633,7 +633,7 @@ public class Settings implements Activity {
 				else {
 					GPULister gpu;
 					int maxRenderbucketSize = 128;        // Max default render bucket size
-					int recommendedBucketSize = 32;        // Default recommended render bucket size
+					int recommendedBucketSize = GPU.MIN_RENDERBUCKET_SIZE; 	// Default recommended render bucket size
 					
 					if (useGPUs.get(counter).getGPUDevice().getType().equals("CUDA")) {
 						gpu = new Nvidia();


### PR DESCRIPTION
The `-renderbucket-size` option is not applied if the app runs in an environment with no configuration file. This PR fixes the bug and also implements all possible argument/config file combinations.