### PR TITLE
Feature: in text UIs, show render progress in one line

### DIFF
--- a/src/com/sheepit/client/Gui.java
+++ b/src/com/sheepit/client/Gui.java
@@ -28,6 +28,8 @@ public interface Gui {
 	
 	public void status(String msg_, boolean overwriteSuspendedMsg);
 	
+	public void status(String msg_, int progress);
+	
 	public void status(String msg_, int progress, long size);
 	
 	public void updateTrayIcon(Integer percentage_);

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -293,10 +293,11 @@ import lombok.Getter;
 			try {
 				int progress = -1;
 				
-				Pattern tilePattern = Pattern.compile(" ([0-9]+)\\s?\\/\\s?([0-9]+) ");
+				Pattern tilePattern = Pattern.compile(" (Rendered|Path Tracing Tile|Rendering) (\\d+)\\s?\\/\\s?(\\d+)( Tiles| samples|,)");
 				
-				// Initialise the progress bar in the icon (0% completed at this time)
+				// Initialise the progress bar in the icon and the UI (0% completed at this time)
 				gui.updateTrayIcon(0);
+				gui.status("Preparing scene", 0);
 				
 				while ((line = input.readLine()) != null) {
 					log.debug(line);
@@ -458,15 +459,16 @@ import lombok.Getter;
 		int newProgress = currentProgress;
 		
 		if (standardTileInfo.find()) {
-			int tileJustProcessed = Integer.parseInt(standardTileInfo.group(1));
-			int totalTilesInJob = Integer.parseInt(standardTileInfo.group(2));
+			int tileJustProcessed = Integer.parseInt(standardTileInfo.group(2));
+			int totalTilesInJob = Integer.parseInt(standardTileInfo.group(3));
 			
 			newProgress = Math.abs((tileJustProcessed * 100) / totalTilesInJob);
 		}
 		
-		// Only update the tray icon if percentage has changed
+		// Only update the tray icon and the screen if percentage has changed
 		if (newProgress != currentProgress) {
 			gui.updateTrayIcon(newProgress);
+			gui.status("Rendering", newProgress);
 		}
 		
 		return newProgress;

--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -191,10 +191,14 @@ public class GuiSwing extends JFrame implements Gui {
 		}
 	}
 	
-	@Override public void status(String msg, int progress, long size) {
+	@Override public void status(String msg, int progress) {
 		if (activityWorking != null) {
 			this.activityWorking.setStatus(String.format("%s %d%%", msg, progress));
 		}
+	}
+	
+	@Override public void status(String msg, int progress, long size) {
+		this.status(msg, progress);
 	}
 	
 	@Override public void setRenderingProjectName(String name_) {

--- a/src/com/sheepit/client/standalone/GuiTextOneLine.java
+++ b/src/com/sheepit/client/standalone/GuiTextOneLine.java
@@ -46,6 +46,7 @@ public class GuiTextOneLine implements Gui {
 	private String computeMethod;
 	private String status;
 	private String line;
+	private String eta;
 	
 	private int uploadQueueSize;
 	private long uploadQueueVolume;
@@ -65,6 +66,7 @@ public class GuiTextOneLine implements Gui {
 		uploadQueueSize = 0;
 		uploadQueueVolume = 0;
 		df = new SimpleDateFormat("MMM dd HH:mm:ss");
+		eta = "";
 	}
 	
 	@Override public void start() {
@@ -123,6 +125,10 @@ public class GuiTextOneLine implements Gui {
 		}
 	}
 	
+	@Override public void status(String msg, int progress) {
+		this.status(msg, progress, 0);
+	}
+	
 	@Override public void status(String msg, int progress, long size) {
 		status = showProgress(msg, progress, size);
 		updateLine();
@@ -160,7 +166,7 @@ public class GuiTextOneLine implements Gui {
 	}
 	
 	@Override public void setRemainingTime(String time_) {
-		status = "Rendering (remaining " + time_ + ")";
+		this.eta = time_;
 		updateLine();
 	}
 	
@@ -224,6 +230,10 @@ public class GuiTextOneLine implements Gui {
 		
 		if (size > 0) {
 			progressBar.append(String.format(" %dMB", (size / 1024 / 1024)));
+		}
+		
+		if (!this.eta.equals("")) {
+			progressBar.append(String.format(" ETA %s", this.eta));
 		}
 		
 		return progressBar.toString();


### PR DESCRIPTION
The text UI gets quite messy during the render process, as it takes at least one extra text line per rendering second. This PR fixes that issue and also shows an ASCII bar to show the render progress.

In addition, the rendering progress is more accurate as is based in the tile processed, not only the ETA provided by Blender.

- OneLine UI screenshot:
![image](https://user-images.githubusercontent.com/4283528/84595026-1a23bb00-ae99-11ea-8576-459bf43b3c3d.png)

- Text UI screenshot:
![image](https://user-images.githubusercontent.com/4283528/84595067-535c2b00-ae99-11ea-91e3-b3ebc1fee13e.png)

The rendering progress is also shown in the GUI in the form _Rendering 45%_.