### PR TITLE
Fix: RENDERER_KILLED error sends a frame reset to server

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -325,6 +325,10 @@ import lombok.Data;
 					
 					ret = this.work(this.renderingJob);
 					if (ret == Error.Type.RENDERER_KILLED) {
+						Job frame_to_reset = this.renderingJob; // copy it because the sendError will take ~5min to execute
+						this.renderingJob = null;
+						this.gui.error(Error.humanString(ret));
+						this.sendError(step, frame_to_reset, ret);
 						this.log.removeCheckPoint(step);
 						continue;
 					}


### PR DESCRIPTION
If a generic RENDERER_KILLED error is triggered in the client, the app is not sending any error to the server and therefore the frame being processed is not reset on the server. This behaviour can cause zombie frames (the server thinks that are being rendered by the client but the process was killed). 

This PR fixes that problem by sending the frame to be reset to the server along with the error information.