### PR TITLE
Fix: HTTPSendFile doesn't send a valid MimeType header to server

### DIFF
--- a/src/com/sheepit/client/Server.java
+++ b/src/com/sheepit/client/Server.java
@@ -475,7 +475,7 @@ public class Server extends Thread {
 		try {
 			String fileMimeType = Files.probeContentType(Paths.get(file1));
 			
-			MediaType MEDIA_TYPE = MediaType.parse("image/" + fileMimeType); // e.g. "image/png"
+			MediaType MEDIA_TYPE = MediaType.parse(fileMimeType); // e.g. "image/png"
 			
 			RequestBody uploadContent = new MultipartBody.Builder().setType(MultipartBody.FORM)
 				.addFormDataPart("file", new File(file1).getName(), RequestBody.create(MEDIA_TYPE, new File(file1))).build();


### PR DESCRIPTION
The HTTPSendFile was adding an "image/" string to the proper file MimeType, rendering the MimeType invalid and not being included in the HTTP header. 