### PR TITLE
Feature: check for HTTP 413 (Entity too large) errors

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -867,7 +867,12 @@ import lombok.Data;
 					// no point to retry the request
 					confirmJobReturnCode = Error.Type.UNKNOWN;
 					break retryLoop;
-				
+					
+				case JOB_VALIDATION_IMAGE_TOO_LARGE:
+					// the client cannot recover from this error (it's server side config) so exit the retry loop
+					confirmJobReturnCode = Type.IMAGE_TOO_LARGE;
+					break retryLoop;
+					
 				default:
 					// do nothing, try to do a request on the next loop
 					break;

--- a/src/com/sheepit/client/Error.java
+++ b/src/com/sheepit/client/Error.java
@@ -23,7 +23,7 @@ public class Error {
 	public enum Type {
 		// id have to be kept synchronised with the server side.
 		OK(0), UNKNOWN(99), WRONG_CONFIGURATION(1), AUTHENTICATION_FAILED(2), TOO_OLD_CLIENT(3), SESSION_DISABLED(4), RENDERER_NOT_AVAILABLE(
-				5), MISSING_RENDERER(6), MISSING_SCENE(7), NOOUTPUTFILE(8), DOWNLOAD_FILE(9), CAN_NOT_CREATE_DIRECTORY(10), NETWORK_ISSUE(11), RENDERER_CRASHED(
+				5), MISSING_RENDERER(6), MISSING_SCENE(7), NOOUTPUTFILE(8), IMAGE_TOO_LARGE(26), DOWNLOAD_FILE(9), CAN_NOT_CREATE_DIRECTORY(10), NETWORK_ISSUE(11), RENDERER_CRASHED(
 				12), RENDERER_CRASHED_PYTHON_ERROR(24), RENDERER_OUT_OF_VIDEO_MEMORY(13), RENDERER_OUT_OF_MEMORY(21), RENDERER_KILLED(
 				14), RENDERER_KILLED_BY_USER(20), RENDERER_KILLED_BY_USER_OVER_TIME(23), RENDERER_KILLED_BY_SERVER(22), RENDERER_MISSING_LIBRARIES(
 				15), FAILED_TO_EXECUTE(16), OS_NOT_SUPPORTED(17), CPU_NOT_SUPPORTED(18), GPU_NOT_SUPPORTED(19), VALIDATION_FAILED(25),
@@ -56,6 +56,7 @@ public class Error {
 		JOB_VALIDATION_ERROR_MISSING_PARAMETER(300), JOB_VALIDATION_ERROR_BROKEN_MACHINE(301), // in GPU the generated frame is black
 		JOB_VALIDATION_ERROR_FRAME_IS_NOT_IMAGE(302), JOB_VALIDATION_ERROR_UPLOAD_FAILED(303), JOB_VALIDATION_ERROR_SESSION_DISABLED(
 				304), // missing heartbeat or broken machine
+		JOB_VALIDATION_IMAGE_TOO_LARGE(306),
 		
 		KEEPMEALIVE_STOP_RENDERING(400),
 		
@@ -124,6 +125,8 @@ public class Error {
 				return "Error while downloading project files. Will try another project in a few minutes.";
 			case NOOUTPUTFILE:
 				return "Renderer has generated no output file, possibly a wrong project configuration or you are missing required libraries. Will try another project in a few minutes.";
+			case IMAGE_TOO_LARGE:
+				return "The generated image is too big to be handled by the server. Will try another project in a few minutes.";
 			case RENDERER_CRASHED:
 				return "Renderer has crashed. It's usually due to a bad project or not enough memory. There is nothing you can do about it. Will try another project in a few minutes.";
 			case RENDERER_CRASHED_PYTHON_ERROR:

--- a/src/com/sheepit/client/Server.java
+++ b/src/com/sheepit/client/Server.java
@@ -510,6 +510,12 @@ public class Server extends Thread {
 			else if (r == HttpURLConnection.HTTP_OK && contentType.startsWith("text/html")) {
 				return ServerCode.ERROR_BAD_RESPONSE;
 			}
+			// We don't check all the HTTP 4xx but the 413 in particular, we can always find a huge image larger than whatever configuration we have in the
+			// server and it's worth to send the error back to the server if this happen
+			else if (r == HttpURLConnection.HTTP_ENTITY_TOO_LARGE) {
+				this.log.error(response.body().string());
+				return ServerCode.JOB_VALIDATION_IMAGE_TOO_LARGE;
+			}
 			else {
 				this.log.error(String.format("Server::HTTPSendFile Unknown response received from server: %s", response.body().string()));
 			}


### PR DESCRIPTION
Add a new error code to handle HTTP 413 errors if returned from the SheepIt Shepherds. The error should be considered catastrophic as there is no way of recovering from an app viewpoint (configuration must be changed in the server to increase the maximum body size).

As part of the PR, the error will be logged and sent back to the server with a new error code `IMAGE_TOO_LONG` to allow SheepIt admins to track the error.
