### PR TITLE
Fix: include any error response from server in error logs

### DIFF
--- a/src/com/sheepit/client/Server.java
+++ b/src/com/sheepit/client/Server.java
@@ -511,7 +511,7 @@ public class Server extends Thread {
 				return ServerCode.ERROR_BAD_RESPONSE;
 			}
 			else {
-				System.out.println(response.body().string());
+				this.log.error(String.format("Server::HTTPSendFile Unknown response received from server: %s", response.body().string()));
 			}
 			
 			return ServerCode.UNKNOWN;


### PR DESCRIPTION
Ensure that the error logs sent to the server include any server response not specifically handled by the client. 