### PR TITLE
Fix: -compute-method argument doesn't work

### DIFF
--- a/src/com/sheepit/client/SettingsLoader.java
+++ b/src/com/sheepit/client/SettingsLoader.java
@@ -361,9 +361,15 @@ public class SettingsLoader {
 			config.setUsePriority(priority);
 		}
 		try {
-			if ((config.getComputeMethod() == null && computeMethod != null) || (computeMethod != null && config.getComputeMethod() != ComputeType
+			if (config.getComputeMethod() == null && computeMethod == null) {
+				config.setComputeMethod(ComputeType.CPU);
+			}
+			else if ((config.getComputeMethod() == null && computeMethod != null) || (computeMethod != null && config.getComputeMethod() != ComputeType
 				.valueOf(computeMethod))) {
-				config.setComputeMethod(ComputeType.valueOf(computeMethod));
+				if (config.getComputeMethod() == null) {
+					config.setComputeMethod(ComputeType.valueOf(computeMethod));
+				}
+				
 			}
 		}
 		catch (IllegalArgumentException e) {

--- a/src/com/sheepit/client/standalone/Worker.java
+++ b/src/com/sheepit/client/standalone/Worker.java
@@ -112,7 +112,7 @@ public class Worker {
 			return;
 		}
 		
-		ComputeType compute_method = ComputeType.CPU;
+		ComputeType compute_method = null;
 		Configuration config = new Configuration(null, login, password);
 		config.setPrintLog(print_log);
 		config.setUsePriority(priority);
@@ -223,10 +223,7 @@ public class Worker {
 			}
 		}
 		else {
-			if (config.getGPUDevice() == null) {
-				compute_method = ComputeType.CPU;
-			}
-			else {
+			if (config.getGPUDevice() != null) {
 				compute_method = ComputeType.GPU;
 			}
 		}
@@ -246,22 +243,24 @@ public class Worker {
 			config.setExtras(extras);
 		}
 		
-		if (compute_method == ComputeType.CPU && config.getGPUDevice() != null) {
-			System.err.println(
+		if (compute_method != null) {
+			if (compute_method == ComputeType.CPU && config.getGPUDevice() != null) {
+				System.err.println(
 					"ERROR: The compute method is set to use CPU only, but a GPU has also been specified. Change the compute method to CPU_GPU or remove the GPU");
-			System.exit(2);
-		}
-		else if (compute_method == ComputeType.CPU_GPU && config.getGPUDevice() == null) {
-			System.err.println(
+				System.exit(2);
+			}
+			else if (compute_method == ComputeType.CPU_GPU && config.getGPUDevice() == null) {
+				System.err.println(
 					"ERROR: The compute method is set to use both CPU and GPU, but no GPU has been specified. Change the compute method to CPU or add a GPU (via -gpu parameter)");
-			System.exit(2);
-		}
-		else if (compute_method == ComputeType.GPU && config.getGPUDevice() == null) {
-			System.err.println("ERROR: The compute method is set to use GPU only, but not GPU has been specified. Please add a GPU (via -gpu parameter)");
-			System.exit(2);
-		}
-		else if (compute_method == ComputeType.CPU) {
-			config.setGPUDevice(null); // remove the GPU
+				System.exit(2);
+			}
+			else if (compute_method == ComputeType.GPU && config.getGPUDevice() == null) {
+				System.err.println("ERROR: The compute method is set to use GPU only, but not GPU has been specified. Please add a GPU (via -gpu parameter)");
+				System.exit(2);
+			}
+			else if (compute_method == ComputeType.CPU) {
+				config.setGPUDevice(null); // remove the GPU
+			}
 		}
 		
 		config.setComputeMethod(compute_method);


### PR DESCRIPTION
The `-compute method` argument doesn't produce any effect on the app. 

The following config-file + `-compute-method` + `-gpu` combinations have been tested:

```
config	-compute-method    -gpu      output    RESULT
NIL     NIL                 NIL      CPU       +OK
NIL     CPU                 NIL      CPU       +OK
NIL     GPU                 NIL      Error     +OK
NIL     GPU                 valid    GPU       +OK
NIL     NIL                 valid    GPU       +OK
NIL     CPU_GPU             NIL      Error     +OK
NIL     CPU_GPU             valid    CPU/GPU   +OK
CPU     NIL                 NIL      CPU       +OK
CPU     NIL                 valid    GPU       +OK
CPU     CPU                 NIL      CPU       +OK
CPU     GPU                 NIL      Error     +OK
CPU     GPU                 valid    GPU       +OK
CPU     CPU_GPU             NIL      Error     +OK
CPU     CPU_GPU             valid    CPU/GPU   +OK
GPU     NIL                 NIL      GPU       +OK
GPU     NIL                 valid    GPU       +OK
GPU     CPU                 NIL      CPU       +OK
GPU     GPU                 NIL      Error     +OK
GPU     GPU                 valid    GPU       +OK
GPU     CPU_GPU             NIL      Error     +OK
GPU     CPU_GPU             valid    CPU/GPU   +OK
```