### PR TITLE
Fix: NULL MimeType when sending files without extension

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -533,7 +533,7 @@ import lombok.Data;
 		
 		this.log.debug("Sending error to server (type: " + error + ")");
 		try {
-			File temp_file = File.createTempFile("farm_", "");
+			File temp_file = File.createTempFile("farm_", ".txt");
 			temp_file.createNewFile();
 			temp_file.deleteOnExit();
 			FileOutputStream writer = new FileOutputStream(temp_file);


### PR DESCRIPTION
To automatically detect the MimeType of the file being sent to the server, the app makes a call to the `Files.probeContentType` method. ProbeContentType uses the file extension to assign the correct MimeType. As files with error log sent to the server don't have any extension (they have a farm_XXXXXXXXXXXXX pattern) the probeContentType method generates a NULL MimeType.

As logs are plain text files, this PR adds the .txt extension to the log files generated to generate the proper MimeType.