### PR TITLE
Fix: add RENDERER_KILLED_BY_USER to download checks

### DIFF
--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -740,7 +740,7 @@ import lombok.Data;
 		// must download the archive
 		Error.Type ret = this.server.HTTPGetFile(url, local_path, this.gui, update_ui);
 		
-		if (ret != Type.RENDERER_KILLED_BY_SERVER || ret != Type.RENDERER_KILLED_BY_USER_OVER_TIME) {
+		if (ret == Type.RENDERER_KILLED_BY_SERVER || ret == Type.RENDERER_KILLED_BY_USER_OVER_TIME || ret == Type.RENDERER_KILLED_BY_USER) {
 			return ret;
 		}
 		


### PR DESCRIPTION
In addition to RENDERER_KILLED_BY_SERVER and RENDERER_KILLED_BY_ USER_OVERTIME, add the user interruption (RENDERER_KILLED_BY_USER) to the reasons to cancel the download and not retry.