### PR TITLE
Fix: NullPointerException triggered when http error in job allocation

### DIFF
--- a/src/com/sheepit/client/Server.java
+++ b/src/com/sheepit/client/Server.java
@@ -474,11 +474,16 @@ public class Server extends Thread {
 		}
 		finally {
 			try {
-				output.flush();
-				output.close();
-				is.close();
+				if (output != null) {
+					output.flush();
+					output.close();
+				}
+				
+				if (is != null) {
+					is.close();
+				}
 			}
-			catch (IOException e) {
+			catch (Exception e) {
 				this.log.debug(String.format("Server::HTTPGetFile Error trying to close the open streams (%s)", e.getMessage()));
 			}
 		}


### PR DESCRIPTION
When an HTTP error is raised in the job allocation process, the current algorithm triggers a NullPointerException that interrupts the program execution and closes gracefully. This PR includes additional checks and also catches all possible exceptions in the process.