### PR TITLE
Fix failed MimeType detection

### DIFF
--- a/src/com/sheepit/client/Server.java
+++ b/src/com/sheepit/client/Server.java
@@ -563,7 +563,7 @@ public class Server extends Thread {
 			return ServerCode.UNKNOWN;
 		}
 	}
-
+	
 	private String generateXMLForMD5cache() {
 		List<FileMD5> md5s = new ArrayList<>();
 		for (File local_file : this.user_config.getLocalCacheFiles()) {

--- a/src/com/sheepit/client/Server.java
+++ b/src/com/sheepit/client/Server.java
@@ -492,8 +492,8 @@ public class Server extends Thread {
 		this.log.debug(checkpoint, "Server::HTTPSendFile(" + surl + "," + file1 + ")");
 		
 		try {
-			String fileMimeType = Files.probeContentType(Paths.get(file1));
-			
+			String fileMimeType = Utils.findMimeType(file1);
+
 			MediaType MEDIA_TYPE = MediaType.parse(fileMimeType); // e.g. "image/png"
 			
 			RequestBody uploadContent = new MultipartBody.Builder().setType(MultipartBody.FORM)
@@ -563,7 +563,7 @@ public class Server extends Thread {
 			return ServerCode.UNKNOWN;
 		}
 	}
-	
+
 	private String generateXMLForMD5cache() {
 		List<FileMD5> md5s = new ArrayList<>();
 		for (File local_file : this.user_config.getLocalCacheFiles()) {

--- a/src/com/sheepit/client/Utils.java
+++ b/src/com/sheepit/client/Utils.java
@@ -19,7 +19,13 @@
 
 package com.sheepit.client;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/src/com/sheepit/client/Utils.java
+++ b/src/com/sheepit/client/Utils.java
@@ -19,11 +19,8 @@
 
 package com.sheepit.client;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.*;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.DigestInputStream;
@@ -211,5 +208,18 @@ public class Utils {
 		}
 		
 		return false;
+	}
+
+	public static String findMimeType(String file1) throws IOException {
+		String mimeType = Files.probeContentType(Paths.get(file1));
+		if (mimeType == null) {
+			InputStream stream = new BufferedInputStream(new FileInputStream(file1));
+			mimeType = URLConnection.guessContentTypeFromStream(stream);
+		}
+		if (mimeType == null) {
+			mimeType = URLConnection.guessContentTypeFromName(file1);
+		}
+
+		return mimeType;
 	}
 }

--- a/src/com/sheepit/client/Utils.java
+++ b/src/com/sheepit/client/Utils.java
@@ -210,14 +210,14 @@ public class Utils {
 		return false;
 	}
 
-	public static String findMimeType(String file1) throws IOException {
-		String mimeType = Files.probeContentType(Paths.get(file1));
+	public static String findMimeType(String file) throws IOException {
+		String mimeType = Files.probeContentType(Paths.get(file));
 		if (mimeType == null) {
-			InputStream stream = new BufferedInputStream(new FileInputStream(file1));
+			InputStream stream = new BufferedInputStream(new FileInputStream(file));
 			mimeType = URLConnection.guessContentTypeFromStream(stream);
 		}
 		if (mimeType == null) {
-			mimeType = URLConnection.guessContentTypeFromName(file1);
+			mimeType = URLConnection.guessContentTypeFromName(file);
 		}
 
 		return mimeType;


### PR DESCRIPTION
A user reported that his upload would continually fail with the following error:

```
java.lang.IllegalArgumentException: Parameter specified as non-null is null: method okhttp3.MediaType$Companion.parse, parameter $this$toMediaTypeOrNull stacktrace java.lang.IllegalArgumentException: Parameter specified as non-null is null: method okhttp3.MediaType$Companion.parse, parameter $this$toMediaTypeOrNull
        at okhttp3.MediaType$Companion.parse(MediaType.kt)
        at okhttp3.MediaType.parse(MediaType.kt)
        at com.sheepit.client.Server.HTTPSendFile(Server.java:497)
        at com.sheepit.client.Client.confirmJob(Client.java:875)
        at com.sheepit.client.Client.run(Client.java:358)
        at com.sheepit.client.standalone.GuiSwing$ThreadClient.run(GuiSwing.java:412)
```

`Files.probeContentType` can return null if the content type is unknown. This PR introduces a Utility method that makes a best guess at the content type, falling back to detection by filename if necessary.