### PR TITLE
 restore missing time remaining time in UI with openCL

### DIFF
--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -211,8 +211,6 @@ import lombok.Getter;
 		if (isUseGPU() && configuration.getGPUDevice() != null && configuration.getComputeMethod() != ComputeType.CPU && OpenCL.TYPE
 				.equals(configuration.getGPUDevice().getType())) {
 			new_env.put("CYCLES_OPENCL_SPLIT_KERNEL_TEST", "1");
-			// how we find remaining time in "console log" for show it in the UI: (using updateRenderingStatus(String) below)
-			this.updateRenderingStatusMethod = UPDATE_METHOD_BY_REMAINING_TIME; 
 		}
 		
 		for (String arg : command1) {

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -211,7 +211,8 @@ import lombok.Getter;
 		if (isUseGPU() && configuration.getGPUDevice() != null && configuration.getComputeMethod() != ComputeType.CPU && OpenCL.TYPE
 				.equals(configuration.getGPUDevice().getType())) {
 			new_env.put("CYCLES_OPENCL_SPLIT_KERNEL_TEST", "1");
-			this.updateRenderingStatusMethod = UPDATE_METHOD_BY_TILE; // don't display remaining time
+			// how we find remaining time in "console log" for show it in the UI: (using updateRenderingStatus(String) below)
+			this.updateRenderingStatusMethod = UPDATE_METHOD_BY_REMAINING_TIME; 
 		}
 		
 		for (String arg : command1) {


### PR DESCRIPTION
When we compute openCL frames, blender engine(s) logs on the console output, the remaining time of a frame.
But we were hiding the result for now. (Why?)
TODO: test under multiple O.S. and with different Blender engines version
Fix for me (under linux and using opencl) #279  