### PR TITLE
Feature: add session data consumption information in GUI/text UIs

### DIFF
--- a/.idea/client-luis.iml
+++ b/.idea/client-luis.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/client-luis.iml
+++ b/.idea/client-luis.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/com/sheepit/client/Client.java
+++ b/src/com/sheepit/client/Client.java
@@ -647,7 +647,7 @@ import lombok.Data;
 					args += "&extras=" + job_to_reset_.getExtras();
 				}
 			}
-			this.server.HTTPSendFile(this.server.getPage("error") + args, temp_file.getAbsolutePath(), step_);
+			this.server.HTTPSendFile(this.server.getPage("error") + args, temp_file.getAbsolutePath(), step_, this.gui);
 			temp_file.delete();
 		}
 		catch (Exception e) {
@@ -938,7 +938,7 @@ import lombok.Data;
 		Type confirmJobReturnCode = Error.Type.OK;
 		retryLoop:
 		while (nb_try < max_try && ret != ServerCode.OK) {
-			ret = this.server.HTTPSendFile(url_real, ajob.getOutputImagePath(), checkpoint);
+			ret = this.server.HTTPSendFile(url_real, ajob.getOutputImagePath(), checkpoint, this.gui);
 			switch (ret) {
 				case OK:
 					// no issue, exit the loop

--- a/src/com/sheepit/client/Gui.java
+++ b/src/com/sheepit/client/Gui.java
@@ -40,6 +40,8 @@ public interface Gui {
 	
 	public void setRenderingTime(String time_);
 	
+	public void  displayTransferStats(TransferStats downloads, TransferStats uploads);
+	
 	public void displayStats(Stats stats);
 	
 	public void displayUploadQueueStats(int queueSize, long queueVolume);

--- a/src/com/sheepit/client/TransferStats.java
+++ b/src/com/sheepit/client/TransferStats.java
@@ -1,10 +1,13 @@
 package com.sheepit.client;
 
+import lombok.AllArgsConstructor;
+
 /****************
  * Holds the session traffic statistics. The constructor accepts two parameters:
  * @long bytes - bytes transferred in the session
  * @Job seconds - seconds spent transferring the data
  */
+@AllArgsConstructor
 public class TransferStats {
 	private long bytes;
 	private long millis;

--- a/src/com/sheepit/client/TransferStats.java
+++ b/src/com/sheepit/client/TransferStats.java
@@ -1,0 +1,33 @@
+package com.sheepit.client;
+
+/****************
+ * Holds the session traffic statistics. The constructor accepts two parameters:
+ * @long bytes - bytes transferred in the session
+ * @Job seconds - seconds spent transferring the data
+ */
+public class TransferStats {
+	private long bytes;
+	private long millis;
+	
+	public TransferStats() {
+		this.bytes = 0;
+		this.millis = 0;
+	}
+	
+	public void calc(long bytes, long millis) {
+		this.bytes += bytes;
+		this.millis += millis;
+	}
+	
+	public String getSessionTraffic() {
+		return Utils.formatDataConsumption(this.bytes);
+	}
+	
+	public String getAverageSessionSpeed() {
+		try {
+			return Utils.formatDataConsumption((long) (this.bytes / (this.millis / 1000f)));
+		} catch (ArithmeticException e) {	// Unlikely, but potential division by zero fallback if first transfer is done in zero millis
+			return Utils.formatDataConsumption((long) (this.bytes / (0.1f)));
+		}
+	}
+}

--- a/src/com/sheepit/client/Utils.java
+++ b/src/com/sheepit/client/Utils.java
@@ -228,4 +228,24 @@ public class Utils {
 
 		return mimeType;
 	}
+	
+	public static String formatDataConsumption(long bytes) {
+		float divider = 0;
+		String suffix = "";
+		
+		if (bytes > 1099511627776f) {    // 1TB
+			divider = 1099511627776f;
+			suffix = "TB";
+		}
+		else if (bytes > 1073741824) {    // 1GB
+			divider = 1073741824;
+			suffix = "GB";
+		}
+		else {    // 1MB
+			divider = 1048576;
+			suffix = "MB";
+		}
+		
+		return String.format("%.2f%s", (bytes / divider), suffix);
+	}
 }

--- a/src/com/sheepit/client/standalone/GuiSwing.java
+++ b/src/com/sheepit/client/standalone/GuiSwing.java
@@ -50,6 +50,7 @@ import com.sheepit.client.Configuration;
 import com.sheepit.client.Gui;
 import com.sheepit.client.SettingsLoader;
 import com.sheepit.client.Stats;
+import com.sheepit.client.TransferStats;
 import com.sheepit.client.standalone.swing.activity.Settings;
 import com.sheepit.client.standalone.swing.activity.Working;
 import lombok.Getter;
@@ -221,6 +222,10 @@ public class GuiSwing extends JFrame implements Gui {
 		if (activityWorking != null) {
 			this.activityWorking.setRenderingTime(time_);
 		}
+	}
+	
+	@Override public synchronized void displayTransferStats(TransferStats downloads, TransferStats uploads) {
+		this.activityWorking.displayTransferStats(downloads, uploads);
 	}
 	
 	@Override public void AddFrameRendered() {

--- a/src/com/sheepit/client/standalone/GuiText.java
+++ b/src/com/sheepit/client/standalone/GuiText.java
@@ -23,6 +23,7 @@ import com.sheepit.client.Client;
 import com.sheepit.client.Gui;
 import com.sheepit.client.Log;
 import com.sheepit.client.Stats;
+import com.sheepit.client.TransferStats;
 import com.sheepit.client.standalone.text.CLIInputActionHandler;
 import com.sheepit.client.standalone.text.CLIInputObserver;
 
@@ -130,6 +131,12 @@ public class GuiText implements Gui {
 	@Override public void AddFrameRendered() {
 		this.framesRendered += 1;
 		System.out.println(String.format("%s Frames rendered: %d", this.df.format(new Date()), this.framesRendered));
+	}
+	
+	@Override public synchronized void displayTransferStats(TransferStats downloads, TransferStats uploads) {
+		System.out.println(String
+			.format("%s Session downloads: %s @ %s/s / Uploads: %s @ %s/s", this.df.format(new Date()), downloads.getSessionTraffic(),
+				downloads.getAverageSessionSpeed(), uploads.getSessionTraffic(), uploads.getAverageSessionSpeed()));
 	}
 	
 	@Override public void displayStats(Stats stats) {

--- a/src/com/sheepit/client/standalone/GuiTextOneLine.java
+++ b/src/com/sheepit/client/standalone/GuiTextOneLine.java
@@ -22,6 +22,7 @@ package com.sheepit.client.standalone;
 import com.sheepit.client.Client;
 import com.sheepit.client.Gui;
 import com.sheepit.client.Stats;
+import com.sheepit.client.TransferStats;
 import com.sheepit.client.standalone.text.CLIInputActionHandler;
 import com.sheepit.client.standalone.text.CLIInputObserver;
 
@@ -152,6 +153,10 @@ public class GuiTextOneLine implements Gui {
 	@Override public void AddFrameRendered() {
 		rendered += 1;
 		updateLine();
+	}
+	
+	@Override public synchronized void displayTransferStats(TransferStats downloads, TransferStats uploads) {
+		// Session traffic stats not shown in the 1 line UI to avoid increasing the line length above 120 chars
 	}
 	
 	@Override public void displayStats(Stats stats) {


### PR DESCRIPTION
Adds the total bytes downloaded and uploaded in the current session as well as the average data transfer rate for both UL/DL. The information is not added to the 1-line UI as the line will take 150+ characters in the screen.

The way of calculating the session arithmetic mean is:

`number of bytes transferred in the session / seconds spent transferring the data`

Downloads and uploads data/time are calculated separately.

Screenshot:
![image](https://user-images.githubusercontent.com/4283528/91631329-1e815e00-ea1c-11ea-915a-31bca829605f.png)

As requested by @Raimund58