### PR TITLE
Feature: support for shared downloads directory

### DIFF
--- a/src/com/sheepit/client/Configuration.java
+++ b/src/com/sheepit/client/Configuration.java
@@ -43,6 +43,7 @@ import lombok.Data;
 	
 	private String configFilePath;
 	private File workingDirectory;
+	private File sharedDownloadsDirectory;
 	private File storageDirectory; // for permanent storage (binary archive)
 	private boolean userHasSpecifiedACacheDir;
 	private String static_exeDirName;
@@ -87,6 +88,7 @@ import lombok.Data;
 		this.userHasSpecifiedACacheDir = false;
 		this.detectGPUs = true;
 		this.workingDirectory = null;
+		this.sharedDownloadsDirectory = null;
 		this.storageDirectory = null;
 		this.setCacheDir(cache_dir_);
 		this.printLog = false;
@@ -147,6 +149,13 @@ import lombok.Data;
 			this.storageDirectory.mkdirs();
 		}
 		
+		if (this.sharedDownloadsDirectory != null) {
+			this.sharedDownloadsDirectory.mkdirs();
+			
+			if (!this.sharedDownloadsDirectory.exists()) {
+				System.err.println("Configuration::setCacheDir Unable to create common directory " + this.sharedDownloadsDirectory.getAbsolutePath());
+			}
+		}
 	}
 	
 	public void setStorageDir(File dir) {

--- a/src/com/sheepit/client/Configuration.java
+++ b/src/com/sheepit/client/Configuration.java
@@ -262,6 +262,12 @@ import lombok.Data;
 				files.addAll(Arrays.asList(filesInDirectory));
 			}
 		}
+		if (this.sharedDownloadsDirectory != null) {
+			File[] filesInDirectory = this.sharedDownloadsDirectory.listFiles();
+			if (filesInDirectory != null) {
+				files.addAll(Arrays.asList(filesInDirectory));
+			}
+		}
 		
 		for (File file : files) {
 			if (file.isFile()) {

--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -141,12 +141,30 @@ import lombok.Getter;
 		return configuration.getWorkingDirectory().getAbsolutePath() + File.separator + rendererMD5;
 	}
 	
+	public String getRequiredRendererArchivePath() {
+		if (configuration.getSharedDownloadsDirectory() != null) {
+			return configuration.getSharedDownloadsDirectory().getAbsolutePath() + File.separator + rendererMD5 + ".zip";
+		}
+		else {
+			return getRendererArchivePath();
+		}
+	}
+	
 	public String getRendererPath() {
 		return getRendererDirectory() + File.separator + OS.getOS().getRenderBinaryPath();
 	}
 	
 	public String getRendererArchivePath() {
 		return configuration.getStorageDir().getAbsolutePath() + File.separator + rendererMD5 + ".zip";
+	}
+	
+	public String getRequiredSceneArchivePath() {
+		if (configuration.getSharedDownloadsDirectory() != null) {
+			return configuration.getSharedDownloadsDirectory().getAbsolutePath() + File.separator + sceneMD5 + ".zip";
+		}
+		else {
+			return getSceneArchivePath();
+		}
 	}
 	
 	public String getSceneDirectory() {

--- a/src/com/sheepit/client/Server.java
+++ b/src/com/sheepit/client/Server.java
@@ -429,7 +429,7 @@ public class Server extends Thread {
 			
 			long start = new Date().getTime();
 			is = response.body().byteStream();
-			output = new FileOutputStream(destination_);
+			output = new FileOutputStream(destination_ + ".partial");
 			
 			long size = response.body().contentLength();
 			byte[] buffer = new byte[8 * 1024];
@@ -478,6 +478,17 @@ public class Server extends Thread {
 					output.close();
 				}
 				
+				File downloadedFile = new File(destination_ + ".partial");
+				
+				if (downloadedFile.exists()) {
+					// Rename file (or directory)
+					boolean success = downloadedFile.renameTo(new File(destination_));
+					
+					if (!success) {
+						this.log.debug(String.format("Server::HTTPGetFile Error trying to rename the downloaded file to final name (%s)", destination_));
+					}
+				}
+
 				if (is != null) {
 					is.close();
 				}
@@ -608,6 +619,14 @@ public class Server extends Thread {
 					File file_to_delete = new File(path + ".zip");
 					file_to_delete.delete();
 					Utils.delete(new File(path));
+					
+					// If we are using a shared downloads directory, then delete the file from the shared downloads directory as well :)
+					if (this.user_config.getSharedDownloadsDirectory() != null) {
+						String commonCacheFile = this.user_config.getSharedDownloadsDirectory().getAbsolutePath() + File.separatorChar + fileMD5.getMd5();
+						this.log.debug("Server::handleFileMD5DeleteDocument delete common file " + commonCacheFile + ".zip");
+						file_to_delete = new File(commonCacheFile + ".zip");
+						file_to_delete.delete();
+					}
 				}
 			}
 		}

--- a/src/com/sheepit/client/standalone/Worker.java
+++ b/src/com/sheepit/client/standalone/Worker.java
@@ -131,7 +131,12 @@ public class Worker {
 		config.setDetectGPUs(!no_gpu_detection);
 		
 		if (sharedDownloadsDir != null) {
-			config.setSharedDownloadsDirectory(new File(sharedDownloadsDir));
+			File dir = new File(sharedDownloadsDir);
+			if (dir.exists() == false || dir.canWrite() == false) {
+				System.err.println("ERROR: The shared-zip directory must exist and be writeable");
+				return;
+			}
+			config.setSharedDownloadsDirectory(dir);
 		}
 		
 		if (cache_dir != null) {

--- a/src/com/sheepit/client/standalone/Worker.java
+++ b/src/com/sheepit/client/standalone/Worker.java
@@ -61,6 +61,8 @@ public class Worker {
 	
 	@Option(name = "-cache-dir", usage = "Cache/Working directory. Caution, everything in it not related to the render-farm will be removed", metaVar = "/tmp/cache", required = false) private String cache_dir = null;
 	
+	@Option(name = "-shared-downloads-dir", usage = "Shared directory for downloaded binaries and scenes. Useful when running two or more clients in the same computer/network to download once and render many times. IMPORTANT: This option and value must be identical in ALL clients sharing the directory.", required = false) private String sharedDownloadsDir = null;
+	
 	@Option(name = "-gpu", usage = "Name of the GPU used for the render, for example CUDA_0 for Nvidia or OPENCL_0 for AMD/Intel card", metaVar = "CUDA_0", required = false) private String gpu_device = null;
 	
 	@Option(name = "--no-gpu", usage = "Don't detect GPUs", required = false) private boolean no_gpu_detection = false;
@@ -127,6 +129,10 @@ public class Worker {
 		config.setPrintLog(print_log);
 		config.setUsePriority(priority);
 		config.setDetectGPUs(!no_gpu_detection);
+		
+		if (sharedDownloadsDir != null) {
+			config.setSharedDownloadsDirectory(new File(sharedDownloadsDir));
+		}
 		
 		if (cache_dir != null) {
 			File a_dir = new File(cache_dir);

--- a/src/com/sheepit/client/standalone/Worker.java
+++ b/src/com/sheepit/client/standalone/Worker.java
@@ -61,7 +61,7 @@ public class Worker {
 	
 	@Option(name = "-cache-dir", usage = "Cache/Working directory. Caution, everything in it not related to the render-farm will be removed", metaVar = "/tmp/cache", required = false) private String cache_dir = null;
 	
-	@Option(name = "-shared-downloads-dir", usage = "Shared directory for downloaded binaries and scenes. Useful when running two or more clients in the same computer/network to download once and render many times. IMPORTANT: This option and value must be identical in ALL clients sharing the directory.", required = false) private String sharedDownloadsDir = null;
+	@Option(name = "-shared-zip", usage = "Shared directory for downloaded binaries and scenes. Useful when running two or more clients in the same computer/network to download once and render many times. IMPORTANT: This option and value must be identical in ALL clients sharing the directory.", required = false) private String sharedDownloadsDir = null;
 	
 	@Option(name = "-gpu", usage = "Name of the GPU used for the render, for example CUDA_0 for Nvidia or OPENCL_0 for AMD/Intel card", metaVar = "CUDA_0", required = false) private String gpu_device = null;
 	


### PR DESCRIPTION
This feature is especially relevant for users with several clients running simultaneously within the same computer (computers running several GPUs or any combination of GPUs + CPUs) or multiple computers running in a network. The feature allows the user to specify a shared downloads directory via the new _-shared-zip_ client option. All the clients using that option will download the binaries and new scenes once and will share them across the clients.

**How it works?**
The first client downloading a binary or scene will save the file in the directory specified in _-shared-zip_. The rest of the clients using the same shared directory will wait until the file has been downloaded. Once the file has been downloaded, it will be ready for the rest of the clients.

This feature is especially relevant for users with metered/slow connections or multiple computers/multiple clients in the same machine that don't want to download the same binary/scene multiple times.

**IMPORTANT: All the clients intended to share the binaries and scenes must execute the client with the same _-shared-zip_ parameter.**
